### PR TITLE
chore: limit dependabot open pull requests to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Purpose

By default Dependabot setting is to open [maximum of 5 pull requests](https://github.com/onfido/castor/network/updates/71640981), then it waits until those are merged or closed. However, we do have e.g. Storybook that itself consists of 7 or more dependencies that should be upgraded all at once.

## Approach

Increase [limit of possible pull requests to be opened](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#open-pull-requests-limit) to 10.

## Testing

After merging Dependabot should be able to open up to 10 PRs.

## Risks

N/A
