### PR TITLE
ci: surge preview

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,33 @@
+name: Preview
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+jobs:
+  preview:
+    name: Preview Storybook
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Deploy preview to Surge
+        uses: afc163/surge-preview@v1
+        id: preview_step
+        env:
+          STORYBOOK_MODE: preview
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          build: |
+            yarn install --frozen-lockfile
+            npx build-storybook -o public
+          dist: 'public'
+          teardown: 'true'
+
+      - name: Get preview URL
+        run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"


### PR DESCRIPTION
## Purpose

Deploy Storybook previews using [Surge](https://surge.sh/).

## Approach

Using [Surge PR Preview](https://github.com/marketplace/actions/surge-pr-preview) action deploying only for pull requests, removing preview when PR is closed (e.g. merged).

## Testing

Essentially when PRs are open at later stages, however tested [here](https://github.com/onfido/castor/pull/25).

## Risks

N/A
