### PR TITLE
chore: release 1.x.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.0.0-rc.1 (2020-12-01)
+
+Initial release.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.1",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/castor",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.1",
   "description": "Onfido's design system.",
   "author": "Onfido",
   "license": "Apache-2.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onfido/castor-react",
-  "version": "0.0.0",
+  "version": "1.0.0-rc.1",
   "description": "React component library for Castor.",
   "author": "Onfido",
   "license": "Apache-2.0",


### PR DESCRIPTION
https://www.npmjs.com/package/@onfido/castor/v/1.0.0-rc.1
https://www.npmjs.com/package/@onfido/castor-react/v/1.0.0-rc.1

Merging version bump back to the `main` branch.
