### PR TITLE
ci: pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  deploy:
+    name: Deploy Storybook
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Git repository
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false # required by JamesIves/github-pages-deploy-action
+
+      - name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Storybook
+        env:
+          STORYBOOK_MODE: production
+          STORYBOOK_GA_ID: ${{ secrets.STORYBOOK_GA_ID }}
+        run: npx build-storybook -o public
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: public
+          CLEAN: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Castor
+# Castor &middot; [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](https://onfido.github.io/castor/)
 
 _Castor_ is Onfido's design system. It is intended to support different renderers, and plain HTML + CSS.
 


### PR DESCRIPTION
## Purpose

Storybook from main branch will be deployed for general use to GitHub Pages.

## Approach

Use [GitHub Pages Deploy Action](https://github.com/JamesIves/github-pages-deploy-action) to deploy.

## Testing

Tested using [test branch](https://github.com/onfido/castor/actions/runs/394266529).

## Risks

N/A
