### PR TITLE
feat(core): remove component transition

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -20,8 +20,6 @@
     padding: castor.space(1.5) - $border-width castor.space(3) - $border-width;
     position: relative;
     text-decoration: none;
-    transition: 0.15s ease;
-    transition-property: background-color, border-color, box-shadow, color;
     width: fit-content;
 
     > * {

--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -14,8 +14,6 @@
     box-sizing: border-box;
     color: castor.color('content-main');
     padding: castor.space(1.5) - $border-width castor.space(2) - $border-width;
-    transition: 0.15s ease;
-    transition-property: border-color, box-shadow, color;
     width: castor.space(50);
 
     &::placeholder {

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -15,8 +15,6 @@
     color: castor.color('content-main');
     padding: castor.space(1.5) - $border-width castor.space(2) - $border-width;
     resize: vertical;
-    transition: 0.15s ease;
-    transition-property: border-color, box-shadow, color;
     width: castor.space(50);
 
     &::placeholder {


### PR DESCRIPTION
## Purpose

Components to not have transition (animation) to feel more snappy.

## Approach

Remove transition from all components.

## Testing

On Storybook preview.

## Risks

N/A
