### PR TITLE
ci: no surge teardown

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,6 @@ name: Preview
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, closed]
     branches-ignore:
       - 'release/*.*.x'
 
@@ -30,7 +29,6 @@ jobs:
             npx build-storybook -o public
           dist: 'public'
           failOnError: 'failed'
-          teardown: 'true'
 
       - name: Get preview URL
         run: echo "url => ${{ steps.preview_step.outputs.preview_url }}"


### PR DESCRIPTION
## Purpose

Surge preview [was added](https://github.com/onfido/castor/pull/26) with possibility to teardown it after PR is merged/closed (following [official example](https://github.com/marketplace/actions/surge-pr-preview#teardown)).

After this now [every PR fails when merging](https://github.com/onfido/castor/pulls?q=is%3Apr+is%3Aclosed), not clear why but I suspect teardown does not work.

## Approach

Removing Surge preview teardown (at least for now).

## Testing

After merging PRs should not be failed.

## Risks

N/A
