### PR TITLE
ci: correct naming main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Purpose

Our primary branch is `main` not `master`, so it should also be used across CI scripts.

Incorrect name introduced with https://github.com/onfido/castor/pull/30.

## Approach

Rename primary branch as `main`.

## Testing

When merging to main branch deployment to GitHub Pages should start.

## Risks

N/A
