### PR TITLE
ci: correct surge teardown

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -12,8 +12,6 @@ jobs:
     steps:
       - name: Checkout Git repository
         uses: actions/checkout@v2
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Deploy preview to Surge
         uses: afc163/surge-preview@v1


### PR DESCRIPTION
## Purpose

Surge preview [was added](https://github.com/onfido/castor/pull/26) with possibility to teardown it after PR is merged/closed (following [official example](https://github.com/marketplace/actions/surge-pr-preview#teardown)), however PRs then  [started to fail after merge](https://github.com/onfido/castor/pulls?q=is%3Apr+is%3Aclosed).

## Approach

Not setting `with:ref` in script, following full example.

If this does not work, we can also [not teardown previews](https://github.com/onfido/castor/pull/32).

## Testing

After merging PRs should not be failed.

## Risks

N/A
