### PR TITLE
docs(react): correct castor-icons repository link

### DIFF
--- a/packages/react/src/icon/icon.react.tsx
+++ b/packages/react/src/icon/icon.react.tsx
@@ -6,8 +6,7 @@ import { c, classy, color, IconProps as BaseProps } from '@onfido/castor';
  * app. If you wish to use individual inlined SVGs, use generated components
  * from Castor Icons package instead.
  *
- * More details:
- * https://gitlab.eu-west-1.mgmt.onfido.xyz/onfido/design/castor-icons
+ * More details: https://github.com/onfido/castor-icons
  */
 export const Icon = ({
   name,


### PR DESCRIPTION
## Purpose

Link to repositories should be to GitHub instead of (old) GitLab.

## Approach

Fixing location of [Castor Icons](https://github.com/onfido/castor-icons).

## Testing

On Storybook preview.

## Risks

N/A
