### PR TITLE
ci: ignore previews on release branches

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,8 @@ name: Preview
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
+    branches-ignore:
+      - 'release/*.*.x'
 
 jobs:
   preview:


### PR DESCRIPTION
## Purpose

Releasing a major version [merging version bump back to main](https://github.com/onfido/castor/pull/27) but preview for such is not needed.

## Approach

Ignore "release" branches from generating previews.

## Testing

Regular PRs should generate previews, but release branches should not.

## Risks

N/A
