### PR TITLE
ci: preview with merge ref

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout Git repository
         uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Deploy preview to Surge
         uses: afc163/surge-preview@v1.5.5


### PR DESCRIPTION
## Purpose

Currently previews generated on pull requests [checks out main branch](https://github.com/onfido/castor/runs/1512084267?check_suite_focus=true#step:2:365) instead of pull request one, causing a preview to not be the right one.

## Approach

Setting reference of a merge to be the one used for building a preview Storybook instance.

This is based on [how action used does this itself](https://github.com/afc163/surge-preview/blob/main/.github/workflows/preview.yml#L13).

## Testing

Unfortunately this cannot be tested until merged to `main`.

## Risks

N/A
