### PR TITLE
ci: fail preview on error

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,7 @@ jobs:
             yarn install --frozen-lockfile
             npx build-storybook -o public
           dist: 'public'
+          failOnError: 'failed'
           teardown: 'true'
 
       - name: Get preview URL


### PR DESCRIPTION
## Purpose

Currently preview pipeline [succeeds even in case of error](https://github.com/onfido/castor/runs/1517210064?check_suite_focus=true#step:3:3188).

## Approach

Set config to [fail pipeline on error](https://github.com/afc163/surge-preview#inputs).

## Testing

Unfortunately this cannot be tested until merged to `main`... After which each PR with failing build of a preview will also be marked as failing.

## Risks

N/A
