### PR TITLE
docs: correct storybook themes

### DIFF
--- a/docs/themer/themes.scss
+++ b/docs/themer/themes.scss
@@ -1,6 +1,6 @@
 @use '~@onfido/castor';
 
 :global {
-  @include castor.day-class();
-  @include castor.night-class();
+  @include castor.day('class');
+  @include castor.night('class');
 }


### PR DESCRIPTION
## Purpose

Recent change [introduced new ways how theme is used](https://github.com/onfido/castor/pull/36), however the change was not applied to Storybook used themes.

This was not cought on pipeline because of [broken preview builder](https://github.com/onfido/castor/pull/58), and then resulted in `main` branch to now [be broken](https://github.com/onfido/castor/commit/d786ecdc21f3f9571862ea12bf4f2ffe1d665b2f).

## Approach

Change theme usage on Storybook.

## Testing

Build tested locally.

## Risks

N/A
