### PR TITLE
feat(core): add border-input-selected color alias

### DIFF
--- a/packages/core/src/helpers/color/color.scss
+++ b/packages/core/src/helpers/color/color.scss
@@ -132,6 +132,7 @@ $aliases: (
   'border-positive-subtle',
   'border-info',
   'border-info-subtle',
+  'border-input-selected',
   'border-focus-inner',
   'border-action-focus',
   'border-negative-focus',

--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -187,6 +187,7 @@ type BorderColor =
   | 'border-positive-subtle'
   | 'border-info'
   | 'border-info-subtle'
+  | 'border-input-selected'
   | 'border-focus-inner'
   | 'border-action-focus'
   | 'border-negative-focus'

--- a/packages/core/src/theme/themes/day.scss
+++ b/packages/core/src/theme/themes/day.scss
@@ -66,6 +66,7 @@
     --color-border-positive-subtle: var(--color-success-muted-300), 1;
     --color-border-info: var(--color-info-500), 1;
     --color-border-info-subtle: var(--color-info-200), 1;
+    --color-border-input-selected: var(--color-primary-500), 1;
     --color-border-focus-inner: var(--color-neutral-white), 1;
     --color-border-action-focus: var(--color-primary-600), 1;
     --color-border-negative-focus: var(--color-error-600), 1;

--- a/packages/core/src/theme/themes/night.scss
+++ b/packages/core/src/theme/themes/night.scss
@@ -66,6 +66,7 @@
     --color-border-positive-subtle: var(--color-success-muted-500), 1;
     --color-border-info: var(--color-info-400), 1;
     --color-border-info-subtle: var(--color-info-muted-600), 1;
+    --color-border-input-selected: var(--color-neutral-200), 1;
     --color-border-focus-inner: var(--color-neutral-900), 1;
     --color-border-action-focus: var(--color-primary-200), 1;
     --color-border-negative-focus: var(--color-error-400), 1;


### PR DESCRIPTION
## Purpose

Add new color alias "border-input-selected".

## Approach

Adding new alias to both "day" and "night" themes.

## Testing

N/A

## Risks

N/A
