### PR TITLE
chore: lint staged scss files

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "lint-staged": {
     "*.{json,md,ts}": "prettier --write",
-    "{.storybook,docs,packages}/**/*.ts{,x}": "eslint --fix"
+    "{.storybook,docs,packages}/**/*.ts{,x}": "eslint --fix",
+    "{.storybook,docs,packages}/**/*.scss": "stylelint --fix"
   }
 }


### PR DESCRIPTION
## Purpose

Additionally lint `*.scss` files when staged.

## Approach

Add `lint-staged` configuration.

## Testing

Tested locally.

## Risks

N/A
