### PR TITLE
chore: dependabot ignore webpack 5 upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: 'webpack'
+        versions: ['5.x']
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Purpose

Upgrading [to webpack 5](https://github.com/onfido/castor/pull/89) on example [fails to build](https://github.com/onfido/castor/pull/89/checks?check_run_id=1537850143).

## Approach

[After discussion](https://github.com/onfido/castor/pull/89#issuecomment-743228890) ignoring Dependabot to upgrade webpack to v5.

Ignoring is [based on official docs](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#ignore), that seem to not have possibility to ignore for specific workflow items.

Downside here that each future webpack major bump will need to be added to this ignore, or otherwise sorted.

## Testing

This needs to be merged in order for Dependabot to take new config into consideration.

## Risks

Our example will only demonstrate use case with webpack 4, for webpack 5 we will hope no issues persist.
