### PR TITLE
refactor(examples): use castor.theme mixin in custom-themes

### DIFF
--- a/examples/custom-themes/src/themes/a.scss
+++ b/examples/custom-themes/src/themes/a.scss
@@ -1,8 +1,10 @@
 @use '~@onfido/castor';
 @use '../tokens' as custom;
 
-// castor themes must have prefix: `.castor-theme--`
-:global .castor-theme--a {
-  @include castor.day();
-  @include custom.tokens();
+:global {
+  // .castor-theme--a
+  @include castor.theme('a', 'class') {
+    @include castor.day();
+    @include custom.tokens(); // override with custom tokens
+  }
 }

--- a/examples/custom-themes/src/themes/b.scss
+++ b/examples/custom-themes/src/themes/b.scss
@@ -1,8 +1,10 @@
 @use '~@onfido/castor';
 @use '../tokens' as custom;
 
-// castor themes must have prefix: `.castor-theme--`
-:global .castor-theme--b {
-  @include castor.night();
-  @include custom.tokens();
+:global {
+  // .castor-theme--b
+  @include castor.theme('b', 'class') {
+    @include castor.night();
+    @include custom.tokens(); // override with custom tokens
+  }
 }


### PR DESCRIPTION
## Purpose

- Have some testing for `castor.theme`
- Reuses class name defined by the mixin
- Cleans up implementation

## Approach

Use `castor.theme` in `a` and `b` custom themes.

## Testing

Local.

## Risks

None.
