### PR TITLE
refactor(eslintrc): only set environment in the appropriate files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,18 +1,11 @@
 {
+  "root": true,
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended"
   ],
-  "env": {
-    "node": true,
-    "browser": true
-  },
-  "settings": {
-    "react": {
-      "version": "detect"
-    }
-  },
+  "settings": { "react": { "version": "detect" } },
   "rules": {
     "@typescript-eslint/explicit-module-boundary-types": "off"
   },

--- a/examples/.eslintrc.json
+++ b/examples/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "env": { "browser": true }
+}

--- a/examples/react-scss-js-webpack/webpack.config.js
+++ b/examples/react-scss-js-webpack/webpack.config.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /* eslint-disable @typescript-eslint/no-var-requires */
 const { resolve } = require('path');
 const WebpackIndexHTMLPlugin = require('@open-wc/webpack-index-html-plugin');


### PR DESCRIPTION
## Purpose

Prevent incorrect usages of e.g. `document` and `require` by only allowing them in appropriate folders/files.

## Approach

- Unset eslintrc env in the root config
- Create eslintrc in `examples` that extends the root and sets `env: browser`
- Use eslint comment in example `webpack` to set `env: node` just for that file

## Testing

`npm run lint`

## Risks

None.
