### PR TITLE
refactor: use template literal types for terser code

### DIFF
--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -38,88 +38,38 @@ export type Palette =
   | WarningColor
   | ErrorColor;
 
-type NeutralColor =
-  | 'neutral-900'
-  | 'neutral-800'
-  | 'neutral-700'
-  | 'neutral-600'
-  | 'neutral-500'
-  | 'neutral-400'
-  | 'neutral-300'
-  | 'neutral-200'
-  | 'neutral-050'
-  | 'neutral-white'
-  | 'neutral-black';
+type Weight =
+  | '900'
+  | '800'
+  | '700'
+  | '600'
+  | '500'
+  | '400'
+  | '300'
+  | '200'
+  | '100'
+  | '050';
 
-type PrimaryColor =
-  | 'primary-700'
-  | 'primary-600'
-  | 'primary-500'
-  | 'primary-400'
-  | 'primary-300'
-  | 'primary-200'
-  | 'primary-100'
-  | 'primary-050'
-  | 'primary-muted-600'
-  | 'primary-muted-300';
+type From700 = Exclude<Weight, '900' | '800'>;
+type From600 = Exclude<From700, '700'>;
 
-type AccentColor =
-  | 'accent-1-600'
-  | 'accent-1-500'
-  | 'accent-1-400'
-  | 'accent-2-600'
-  | 'accent-2-500'
-  | 'accent-2-400'
-  | 'accent-3-600'
-  | 'accent-3-500'
-  | 'accent-3-400';
+type Muted = `muted-${'600' | '300'}`;
+type MutedLight = `muted-${'500' | '300'}`;
+type Vivid = 'vivid-300';
 
-type SuccessColor =
-  | 'success-600'
-  | 'success-500'
-  | 'success-400'
-  | 'success-300'
-  | 'success-200'
-  | 'success-100'
-  | 'success-050'
-  | 'success-vivid-300'
-  | 'success-muted-500'
-  | 'success-muted-300';
+type NeutralColor = `neutral-${Exclude<Weight, '100'> | 'white' | 'black'}`;
 
-type InfoColor =
-  | 'info-700'
-  | 'info-600'
-  | 'info-500'
-  | 'info-400'
-  | 'info-300'
-  | 'info-200'
-  | 'info-100'
-  | 'info-050'
-  | 'info-muted-600'
-  | 'info-muted-300';
+type PrimaryColor = `primary-${From700 | Muted}`;
 
-type WarningColor =
-  | 'warning-600'
-  | 'warning-500'
-  | 'warning-400'
-  | 'warning-300'
-  | 'warning-200'
-  | 'warning-100'
-  | 'warning-050'
-  | 'warning-vivid-300'
-  | 'warning-muted-500'
-  | 'warning-muted-300';
+type AccentColor = `accent-${'1' | '2' | '3'}-${'600' | '500' | '400'}`;
 
-type ErrorColor =
-  | 'error-600'
-  | 'error-500'
-  | 'error-400'
-  | 'error-300'
-  | 'error-200'
-  | 'error-100'
-  | 'error-050'
-  | 'error-muted-500'
-  | 'error-muted-300';
+type SuccessColor = `success-${From600 | Vivid | MutedLight}`;
+
+type InfoColor = `info-${From600 | Muted}`;
+
+type WarningColor = `warning-${From600 | Vivid | MutedLight}`;
+
+type ErrorColor = `error-${From600 | MutedLight}`;
 
 type ContentColor =
   | 'content-main'

--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -38,7 +38,7 @@ export type Palette =
   | WarningColor
   | ErrorColor;
 
-type Weight =
+type ColorWeight =
   | '900'
   | '800'
   | '700'
@@ -50,31 +50,38 @@ type Weight =
   | '100'
   | '050';
 
-type Muted = `muted-${'600' | '300'}`;
-type MutedLight = `muted-${'500' | '300'}`;
-type Vivid = 'vivid-300';
+type ColorMuted = `muted-${Extract<ColorWeight, '600' | '300'>}`;
+type ColorMutedLight = `muted-${Extract<ColorWeight, '500' | '300'>}`;
+type ColorVivid = `vivid-${Extract<ColorWeight, '300'>}`;
 
-type NeutralColor = `neutral-${Exclude<Weight, '100'> | 'white' | 'black'}`;
+type NeutralColor = `neutral-${
+  | Exclude<ColorWeight, '100'>
+  | 'white'
+  | 'black'}`;
 
-type PrimaryColor = `primary-${Exclude<Weight, '900' | '800'> | Muted}`;
+type PrimaryColor = `primary-${
+  | Exclude<ColorWeight, '900' | '800'>
+  | ColorMuted}`;
 
 type AccentColor = `accent-${'1' | '2' | '3'}-${'600' | '500' | '400'}`;
 
 type SuccessColor = `success-${
-  | Exclude<Weight, '900' | '800' | '700'>
-  | Vivid
-  | MutedLight}`;
+  | Exclude<ColorWeight, '900' | '800' | '700'>
+  | ColorVivid
+  | ColorMutedLight}`;
 
-type InfoColor = `info-${Exclude<Weight, '900' | '800' | '700'> | Muted}`;
+type InfoColor = `info-${
+  | Exclude<ColorWeight, '900' | '800' | '700'>
+  | ColorMuted}`;
 
 type WarningColor = `warning-${
-  | Exclude<Weight, '900' | '800' | '700'>
-  | Vivid
-  | MutedLight}`;
+  | Exclude<ColorWeight, '900' | '800' | '700'>
+  | ColorVivid
+  | ColorMutedLight}`;
 
 type ErrorColor = `error-${
-  | Exclude<Weight, '900' | '800' | '700'>
-  | MutedLight}`;
+  | Exclude<ColorWeight, '900' | '800' | '700'>
+  | ColorMutedLight}`;
 
 type ContentColor =
   | 'content-main'

--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -63,7 +63,8 @@ type PrimaryColor = `primary-${
   | Exclude<ColorWeight, '900' | '800'>
   | ColorMuted}`;
 
-type AccentColor = `accent-${'1' | '2' | '3'}-${'600' | '500' | '400'}`;
+type AccentColor = `accent-${'1' | '2' | '3'}-${AccentWeight}`;
+type AccentWeight = Extract<ColorWeight, '600' | '500' | '400'>;
 
 type SuccessColor = `success-${
   | Exclude<ColorWeight, '900' | '800' | '700'>

--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -50,26 +50,31 @@ type Weight =
   | '100'
   | '050';
 
-type From700 = Exclude<Weight, '900' | '800'>;
-type From600 = Exclude<From700, '700'>;
-
 type Muted = `muted-${'600' | '300'}`;
 type MutedLight = `muted-${'500' | '300'}`;
 type Vivid = 'vivid-300';
 
 type NeutralColor = `neutral-${Exclude<Weight, '100'> | 'white' | 'black'}`;
 
-type PrimaryColor = `primary-${From700 | Muted}`;
+type PrimaryColor = `primary-${Exclude<Weight, '900' | '800'> | Muted}`;
 
 type AccentColor = `accent-${'1' | '2' | '3'}-${'600' | '500' | '400'}`;
 
-type SuccessColor = `success-${From600 | Vivid | MutedLight}`;
+type SuccessColor = `success-${
+  | Exclude<Weight, '900' | '800' | '700'>
+  | Vivid
+  | MutedLight}`;
 
-type InfoColor = `info-${From600 | Muted}`;
+type InfoColor = `info-${Exclude<Weight, '900' | '800' | '700'> | Muted}`;
 
-type WarningColor = `warning-${From600 | Vivid | MutedLight}`;
+type WarningColor = `warning-${
+  | Exclude<Weight, '900' | '800' | '700'>
+  | Vivid
+  | MutedLight}`;
 
-type ErrorColor = `error-${From600 | MutedLight}`;
+type ErrorColor = `error-${
+  | Exclude<Weight, '900' | '800' | '700'>
+  | MutedLight}`;
 
 type ContentColor =
   | 'content-main'

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -41,37 +41,19 @@ export function font(name: FontName): Font {
 
 export type Font = Pick<
   CSSProperties,
-  'fontFamily' | 'fontSize' | 'fontWeight' | 'lineHeight' | 'textTransform'
+  `font${'Family' | 'Size' | 'Weight'}` | 'lineHeight' | 'textTransform'
 >;
 
 export type FontName =
-  | '800-bold'
-  | '700-bold'
-  | '600-bold'
-  | '500-bold'
-  | '400-bold'
-  | '300-bold'
-  | '200-bold'
-  | '100-bold'
-  | '800-regular'
-  | '700-regular'
-  | '600-regular'
-  | '500-regular'
-  | '400-regular'
-  | '300-regular'
-  | '200-regular'
-  | '100-regular'
-  | '800-light'
-  | '700-light'
-  | '600-light'
-  | '500-light'
-  | '400-allcaps'
-  | '300-allcaps'
-  | '200-allcaps'
-  | '100-allcaps'
-  | '400-mono'
-  | '300-mono'
-  | '200-mono';
+  | `${FontSize}-bold`
+  | `${FontSize}-regular`
+  | `${LargeFont}-light`
+  | `${SmallFont}-allcaps`
+  | `${Exclude<SmallFont, '100'>}-mono`;
+
+type FontSize = keyof typeof sizes;
+type LargeFont = Exclude<FontSize, '400' | '300' | '200' | '100'>;
+type SmallFont = Exclude<FontSize, LargeFont>;
 
 const sizes = {
   '800': {
@@ -108,7 +90,7 @@ const sizes = {
   },
 };
 
-type FontSize = '800' | '700' | '600' | '500' | '400' | '300' | '200' | '100';
+type FontType = keyof typeof types;
 
 const types = {
   bold: {
@@ -127,5 +109,3 @@ const types = {
     fontFamily: '"Roboto Mono", monospace',
   },
 };
-
-type FontType = 'bold' | 'regular' | 'light' | 'allcaps' | 'mono';

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -47,9 +47,9 @@ export type Font = Pick<
 export type FontName =
   | `${FontSize}-bold`
   | `${FontSize}-regular`
-  | `${Exclude<FontSize, '800' | '700' | '600' | '500'>}-light`
-  | `${Exclude<FontSize, '400' | '300' | '200' | '100'>}-allcaps`
-  | `${Exclude<FontSize, '400' | '300' | '200'>}-mono`;
+  | `${Extract<FontSize, '800' | '700' | '600' | '500'>}-light`
+  | `${Extract<FontSize, '400' | '300' | '200' | '100'>}-allcaps`
+  | `${Extract<FontSize, '400' | '300' | '200'>}-mono`;
 
 type FontSize = keyof typeof sizes;
 

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -47,13 +47,11 @@ export type Font = Pick<
 export type FontName =
   | `${FontSize}-bold`
   | `${FontSize}-regular`
-  | `${LargeFont}-light`
-  | `${SmallFont}-allcaps`
-  | `${Exclude<SmallFont, '100'>}-mono`;
+  | `${Exclude<FontSize, '800' | '700' | '600' | '500'>}-light`
+  | `${Exclude<FontSize, '400' | '300' | '200' | '100'>}-allcaps`
+  | `${Exclude<FontSize, '400' | '300' | '200'>}-mono`;
 
 type FontSize = keyof typeof sizes;
-type LargeFont = Exclude<FontSize, '400' | '300' | '200' | '100'>;
-type SmallFont = Exclude<FontSize, LargeFont>;
 
 const sizes = {
   '800': {


### PR DESCRIPTION
## Purpose

With newly introduced [template literal types](https://devblogs.microsoft.com/typescript/announcing-typescript-4-1/#template-literal-types) we can write terser code.

## Approach

Reuse type variants as much as possible in `color` and `font`.

## Testing

CI checks.

## Risks

Highly subjective to personal preference.

Note: the outcome is still the same, hovering the type name shows the same type union.
