### PR TITLE
build: run linters for all appropriate files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,9 +34,7 @@ jobs:
           eslint_extensions: 'js,jsx,ts,tsx'
           stylelint: true
           stylelint_args: '--ignore-path .gitignore --max-warnings 0'
-          stylelint_extensions: 'css,scss'
           prettier: true
           prettier_args: '--ignore-path .gitignore'
-          prettier_extensions: 'js,jsx,json,md,ts,tsx,yml'
           # Additionally configure action:
           commit_message: 'style: fix code issues with ${linter}'

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*": "prettier --write",
+  "*.{js,jsx,ts,tsx,css,scss,yml,html,md,mdx,json}": "prettier --write",
   "*.{j,t}s{,x}": "eslint --fix",
   "*.{,s}css": "stylelint --fix"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "*.{js,jsx,ts,tsx,css,scss,yml,html,md,mdx,json}": "prettier --write",
+  "*.{js,jsx,ts,tsx,css,scss,html,md,mdx,json,yml}": "prettier --write",
   "*.{j,t}s{,x}": "eslint --fix",
   "*.{,s}css": "stylelint --fix"
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,0 +1,5 @@
+{
+  "*": "prettier --write",
+  "*.{j,t}s{,x}": "eslint --fix",
+  "*.{,s}css": "stylelint --fix"
+}

--- a/package.json
+++ b/package.json
@@ -58,10 +58,5 @@
     "stylelint-config-sass-guidelines": "^7.1.0",
     "ts-jest": "^26.4.4",
     "typescript": "^4.1.3"
-  },
-  "lint-staged": {
-    "*.{js,jsx,json,md,ts,tsx,yml}": "prettier --write",
-    "{.storybook,docs,examples,packages}/**/*.{js,jsx,ts,tsx}": "eslint --fix",
-    "{.storybook,docs,examples,packages}/**/*.{,s}css": "stylelint --fix"
   }
 }


### PR DESCRIPTION
## Purpose

Make sure both GitHub Actions and lint-staged target all appropriate files for each linter.

## Approach

Keeping in mind that staged files already exclude files specified in `.gitignore`, in line with package.json scripts.

- Extract lint-staged config from package.json into its own config file (optional)
- Make `prettier` run for all staged files
- Make `eslint` run for all staged `js`, `jsx`, `ts` and `tsx` files
- Make `stylelint` run for all staged `css` and `scss` files
- Use `wearerequired/lint-action@v1` default extensions for `stylelint` and `prettier`, which cover all we need

## Testing

Update files of all linted extensions, commit, confirm all linters run correctly.

## Risks

lint-staged separate config file subject to personal taste.
