### PR TITLE
refactor(core): make "space" helper similar between .ts and .scss

### DIFF
--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -22,9 +22,8 @@ export function color(name: Color): string;
 export function color(name: Palette, opacity?: number): string;
 
 export function color(name: Color, opacity?: number): string {
-  return opacity
-    ? `rgba(var(--ods-color-${name}), ${opacity})`
-    : `rgba(var(--ods-color-${name}))`;
+  const alpha = opacity ? `, ${opacity}` : '';
+  return `rgba(var(--ods-color-${name})${alpha})`;
 }
 
 export type Color = ContentColor | BackgroundColor | BorderColor | Palette;

--- a/packages/core/src/helpers/color/color.ts
+++ b/packages/core/src/helpers/color/color.ts
@@ -22,8 +22,9 @@ export function color(name: Color): string;
 export function color(name: Palette, opacity?: number): string;
 
 export function color(name: Color, opacity?: number): string {
-  const alpha = opacity ? `, ${opacity}` : '';
-  return `rgba(var(--ods-color-${name})${alpha})`;
+  return opacity
+    ? `rgba(var(--ods-color-${name}), ${opacity})`
+    : `rgba(var(--ods-color-${name}))`;
 }
 
 export type Color = ContentColor | BackgroundColor | BorderColor | Palette;

--- a/packages/core/src/helpers/space/space.scss
+++ b/packages/core/src/helpers/space/space.scss
@@ -3,7 +3,7 @@ $base: 8px;
 
 @function space($multiplier) {
   @if not is-allowed($multiplier) {
-    @error '$number must be an integer or one of (#{$allowed-floats})';
+    @error '$multiplier must be an integer or (#{$allowed-floats}). Got: #{$multiplier}';
   }
 
   @return $multiplier * $base;

--- a/packages/core/src/helpers/space/space.scss
+++ b/packages/core/src/helpers/space/space.scss
@@ -1,11 +1,18 @@
-$allowed-fractionals: (1.5, 0.5, 0.25, 0.125);
-
+$allowed-floats: (1.5, 0.5, 0.25, 0.125);
 $base: 8px;
 
-@function space($number) {
-  @if $number % 1 != 0 and not index($allowed-fractionals, $number) {
-    @error '$number must be an integer or one of (#{$allowed-fractionals})';
+@function space($multiplier) {
+  @if not is-allowed($multiplier) {
+    @error '$number must be an integer or one of (#{$allowed-floats})';
   }
 
-  @return $number * $base;
+  @return $multiplier * $base;
+}
+
+@function is-allowed($multiplier) {
+  @return is-integer($multiplier) or index($allowed-floats, $multiplier);
+}
+
+@function is-integer($number) {
+  @return $number % 1 == 0;
 }

--- a/packages/core/src/helpers/space/space.scss
+++ b/packages/core/src/helpers/space/space.scss
@@ -3,7 +3,7 @@ $base: 8px;
 
 @function space($multiplier) {
   @if not is-allowed($multiplier) {
-    @error '$multiplier must be an integer or (#{$allowed-floats}). Got: #{$multiplier}';
+    @error '$multiplier must be an integer or (#{$allowed-floats})';
   }
 
   @return $multiplier * $base;

--- a/packages/core/src/helpers/space/space.spec.ts
+++ b/packages/core/src/helpers/space/space.spec.ts
@@ -2,22 +2,20 @@ import { describe, expect, it } from '@jest/globals';
 import { space } from './space';
 
 describe('space', () => {
-  const allowedFloats = [1.5, 0.5, 0.25, 0.125];
-  allowedFloats.toString = () => `(${allowedFloats.join(', ')})`;
-  const base = 8;
-
   it('should return the correct "multiplier * base" value', () => {
     expect(space(1)).toBe('8px');
   });
 
-  it(`should allow ${allowedFloats}`, () => {
-    for (const float of allowedFloats)
-      expect(space(float)).toBe(`${float * base}px`);
+  it('should allow (1.5, 0.5, 0.25, 0.125)', () => {
+    expect(space(1.5)).toBe('12px');
+    expect(space(0.5)).toBe('4px');
+    expect(space(0.25)).toBe('2px');
+    expect(space(0.125)).toBe('1px');
   });
 
-  it(`should throw for non integers and not in ${allowedFloats}`, () => {
-    expect(() => space(2.5)).toThrow(
-      `"multiplier" must be an integer or ${allowedFloats}`
+  it('should throw for non integers or not in (1.5, 0.5, 0.25, 0.125)', () => {
+    expect(() => space(2.5)).toThrowError(
+      '"multiplier" must be an integer or (1.5, 0.5, 0.25, 0.125)'
     );
   });
 });

--- a/packages/core/src/helpers/space/space.spec.ts
+++ b/packages/core/src/helpers/space/space.spec.ts
@@ -2,20 +2,22 @@ import { describe, expect, it } from '@jest/globals';
 import { space } from './space';
 
 describe('space', () => {
+  const allowedFloats = [1.5, 0.5, 0.25, 0.125];
+  allowedFloats.toString = () => `(${allowedFloats.join(', ')})`;
+  const base = 8;
+
   it('should return the correct "multiplier * base" value', () => {
     expect(space(1)).toBe('8px');
   });
 
-  it('should allow (1.5, 0.5, 0.25, 0.125)', () => {
-    expect(space(1.5)).toBe('12px');
-    expect(space(0.5)).toBe('4px');
-    expect(space(0.25)).toBe('2px');
-    expect(space(0.125)).toBe('1px');
+  it(`should allow ${allowedFloats}`, () => {
+    for (const float of allowedFloats)
+      expect(space(float)).toBe(`${float * base}px`);
   });
 
-  it('should throw for non integers or not in (1.5, 0.5, 0.25, 0.125)', () => {
-    expect(() => space(2.5)).toThrowError(
-      '"multiplier" must be an integer or (1.5, 0.5, 0.25, 0.125). Got: 2.5'
+  it(`should throw for non integers and not in ${allowedFloats}`, () => {
+    expect(() => space(2.5)).toThrow(
+      `"multiplier" must be an integer or ${allowedFloats}`
     );
   });
 });

--- a/packages/core/src/helpers/space/space.ts
+++ b/packages/core/src/helpers/space/space.ts
@@ -1,7 +1,7 @@
 /**
  * Returns the `px` size of a multiplier of the base space.
  *
- * Only integers and (1.5, 0.5, 0.25, 0.125) are supported.
+ * @note Only integers and (1.5, 0.5, 0.25, 0.125) are supported.
  *
  * @param multiplier How much to multiply the base.
  *
@@ -12,15 +12,16 @@
 export function space(multiplier: number): string {
   if (!isAllowed(multiplier))
     throw new Error(
-      `"multiplier" must be an integer or (${floats}). Got: ${multiplier}`
+      `"multiplier" must be an integer or (${allowedFloats}). Got: ${multiplier}`
     );
 
   return `${multiplier * base}px`;
 }
 
-const allowedFractionals = new Set([1.5, 0.5, 0.25, 0.125]);
+const allowedFloats = new Set([1.5, 0.5, 0.25, 0.125]);
+allowedFloats.toString = () => [...allowedFloats].join(', ');
+
 const base = 8;
-const floats = [...allowedFractionals].join(', ');
 
 const isAllowed = (multiplier: number) =>
-  Number.isInteger(multiplier) || allowedFractionals.has(multiplier);
+  Number.isInteger(multiplier) || allowedFloats.has(multiplier);

--- a/packages/core/src/helpers/space/space.ts
+++ b/packages/core/src/helpers/space/space.ts
@@ -11,9 +11,7 @@
  */
 export function space(multiplier: number): string {
   if (!isAllowed(multiplier))
-    throw new Error(
-      `"multiplier" must be an integer or (${allowedFloats}). Got: ${multiplier}`
-    );
+    throw new Error(`"multiplier" must be an integer or (${allowedFloats})`);
 
   return `${multiplier * base}px`;
 }

--- a/packages/core/src/helpers/space/space.ts
+++ b/packages/core/src/helpers/space/space.ts
@@ -10,16 +10,17 @@
  * // '32px'
  */
 export function space(multiplier: number): string {
-  if (!isAllowed(multiplier)) {
-    const msg = '"multiplier" must be an integer or (1.5, 0.5, 0.25, 0.125)';
-    throw new Error(`${msg}. Got: ${multiplier}`);
-  }
+  if (!isAllowed(multiplier))
+    throw new Error(
+      `"multiplier" must be an integer or (${floats}). Got: ${multiplier}`
+    );
 
   return `${multiplier * base}px`;
 }
 
 const allowedFractionals = new Set([1.5, 0.5, 0.25, 0.125]);
 const base = 8;
+const floats = [...allowedFractionals].join(', ');
 
 const isAllowed = (multiplier: number) =>
   Number.isInteger(multiplier) || allowedFractionals.has(multiplier);

--- a/packages/core/src/helpers/space/space.ts
+++ b/packages/core/src/helpers/space/space.ts
@@ -1,7 +1,7 @@
 /**
  * Returns the `px` size of a multiplier of the base space.
  *
- * @note Only integers and (1.5, 0.5, 0.25, 0.125) are supported.
+ * Only integers and (1.5, 0.5, 0.25, 0.125) are supported.
  *
  * @param multiplier How much to multiply the base.
  *


### PR DESCRIPTION
## Purpose

Refactors `space` for better maintainability, error messages, variable reutilisation, and parity between TS and Sass.

## Approach

- Reuse `space`'s `allowedFloats` to interpolate floating numbers allowed
- Rename variables to match between languages
- Reorganise code structure to make them better match

## Testing

`npm run test`

## Risks

None?