### PR TITLE
chore: use official npm registry when executing yarn

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-registry=https://registry.npmjs.org/

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+"registry" "https://registry.npmjs.org"


### PR DESCRIPTION
## Purpose

Previously a change introduced a [usage of official npm registry](https://github.com/onfido/castor/pull/121), however as Yarn is used it also needs to be configured to keep using this registry.

## Approach

Instead of setting registry for npm, now setting it for Yarn.

## Testing

Locally tried to upgrade a package, and checked that registry persist.

## Risks

Not sure how Dependabot will react to the change.
