### PR TITLE
chore: do not use github dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/124 removing usage of GitHub's Dependabot (beta) version completely, because still:

![Screenshot 2020-12-22 at 17 13 24](https://user-images.githubusercontent.com/20243687/102903475-4cc1f800-4468-11eb-81eb-1b00105ff818.png)

## Approach

Removing `.dependabot.yml` removes integration.

## Testing

Yet again, can't test this until merged...

## Risks

Might be that Dependabot Preview app will still not work for some reason.
