### PR TITLE
ci: commitlint exclude dependabot (preview)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run commitlint
-        if: github.actor != 'dependabot[bot]' # allow long commit message body
+        if: github.actor != 'dependabot-preview[bot]' # allow long commit message body
         run: yarn lint:commit
 
       - name: Run all other linters


### PR DESCRIPTION
## Purpose

Based on https://github.com/onfido/castor-icons/pull/15 we now use Dependabot Preview that has a different commit actor.

## Approach

Change Dependabot actor from `dependabot` to `dependabot-preview`.

## Testing

Only after merge - rebased Dependabot PRs should not be failing anymore.

## Risks

N/A
