### PR TITLE
chore: set default dependabot labels

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,6 +4,9 @@ update_configs:
   - package_manager: 'javascript'
     directory: '/'
     update_schedule: 'daily'
+    default_labels:
+      - 'dependencies'
+      - 'javascript'
     ignored_updates:
       - match:
           dependency_name: 'webpack'


### PR DESCRIPTION
## Purpose

Dependabot Preview by [default only adds "dependencies" label](https://dependabot.com/docs/config-file/#default_labels), and so is different from our previous usage as it was also setting "javascript" label:

![Screenshot 2020-12-22 at 17 52 57](https://user-images.githubusercontent.com/20243687/102907308-c7d9dd00-446d-11eb-8d76-0c1ba5807778.png)

## Approach

Align with previous behaviours by also adding "javascript" label.

## Testing

Can only be tested once Dependabot opens a new PR.

## Risks

Don't know exactly how it works for other labels, e.g. "security" but should be all fine.
