### PR TITLE
fix(react): export search component

### DIFF
--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './button/button.react';
 export * from './icon/icon.react';
 export * from './input/input.react';
+export * from './search/search.react';
 export * from './textarea/textarea.react';


### PR DESCRIPTION
## Purpose

Export Search component for React.

Component can still be used, however can't be `import { Search } from "@onfido/castor-react"`.

## Approach

Add to main component exports of React package.

## Testing

Tested locally.

## Risks

This might repeat for future components, @rabelloo we should think of testing the export of all components.
