### PR TITLE
refactor(react): import from castor-react package

### DIFF
--- a/packages/react/src/components/button/button.react.stories.tsx
+++ b/packages/react/src/components/button/button.react.stories.tsx
@@ -1,9 +1,8 @@
 import { space } from '@onfido/castor';
 import { IconName, iconNames } from '@onfido/castor-icons';
+import { Button, ButtonProps, Icon } from '@onfido/castor-react';
 import React, { SyntheticEvent } from 'react';
-import { Icon } from '../';
 import { Meta, omit, Story, storyOf } from '../../../../../docs';
-import { Button, ButtonProps } from './button.react';
 
 export default {
   title: 'React/Button',

--- a/packages/react/src/components/icon/icon.react.stories.tsx
+++ b/packages/react/src/components/icon/icon.react.stories.tsx
@@ -1,8 +1,8 @@
 import { Color } from '@onfido/castor';
 import { iconNames } from '@onfido/castor-icons';
+import { Icon, IconProps } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, Story, storyOf, tokens } from '../../../../../docs';
-import { Icon, IconProps } from './icon.react';
 
 const colors = Object.keys(tokens).reduce((accumulator, name) => {
   const [, color] = name.match(/^--ods-color-([a-z0-9-]+)$/) ?? [];

--- a/packages/react/src/components/input/input.react.stories.tsx
+++ b/packages/react/src/components/input/input.react.stories.tsx
@@ -1,6 +1,6 @@
+import { Input, InputProps } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, Story, storyOf } from '../../../../../docs';
-import { Input, InputProps } from './input.react';
 
 export default {
   title: 'React/Input',

--- a/packages/react/src/components/search/search.react.stories.tsx
+++ b/packages/react/src/components/search/search.react.stories.tsx
@@ -1,6 +1,6 @@
+import { Search, SearchProps } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, Story, storyOf } from '../../../../../docs';
-import { Search, SearchProps } from './search.react';
 
 export default {
   title: 'React/Search',

--- a/packages/react/src/components/textarea/textarea.react.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.react.stories.tsx
@@ -1,6 +1,6 @@
+import { Textarea, TextareaProps } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, Story, storyOf } from '../../../../../docs';
-import { Textarea, TextareaProps } from './textarea.react';
 
 export default {
   title: 'React/Textarea',


### PR DESCRIPTION
## Purpose

Recently [component was not properly exported](https://github.com/onfido/castor/pull/141) and we had no easy way of testing such to potentially avoid in the future.

## Approach

Within Storybook importing React components directly from `@onfido/castor-react` to make sure it replicates actualy package usage.

## Testing

Storybook should function properly.

## Risks

N/A
