### PR TITLE
refactor(core): make sass variables private

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,8 +3,8 @@
   "rules": {
     "max-nesting-depth": [1, { "ignore": ["pseudo-classes"] }],
     "selector-class-pattern": "^-?[a-z]+(?:--?[a-z]+)*$",
-    "scss/dollar-variable-pattern": "^[a-z]+(?:-[a-z]+)*$",
-    "scss/at-function-pattern": "^[a-z]+(?:-[a-z]+)*$",
+    "scss/dollar-variable-pattern": "^_?[a-z]+(?:-[a-z]+)*$",
+    "scss/at-function-pattern": "^_?[a-z]+(?:-[a-z]+)*$",
     "scss/at-mixin-pattern": "^[A-Z]?[a-z]+(?:-[a-z]+)*$",
     "scss/at-mixin-argumentless-call-parentheses": "always",
     "scss/at-rule-conditional-no-parentheses": true,

--- a/packages/core/src/helpers/border-radius/border-radius.scss
+++ b/packages/core/src/helpers/border-radius/border-radius.scss
@@ -1,8 +1,8 @@
-$allowed-sizes: ('small', 'medium', 'large', 'full');
+$_allowed-sizes: ('small', 'medium', 'large', 'full');
 
 @function border-radius($size) {
-  @if not index($allowed-sizes, $size) {
-    @error '$size must be one of (#{$allowed-sizes})';
+  @if not index($_allowed-sizes, $size) {
+    @error '$size must be one of (#{$_allowed-sizes})';
   }
 
   @return var(--ods-border-radius-#{$size});

--- a/packages/core/src/helpers/color/color.scss
+++ b/packages/core/src/helpers/color/color.scss
@@ -1,4 +1,4 @@
-$palette: (
+$_palette: (
   'neutral-900',
   'neutral-800',
   'neutral-700',
@@ -70,7 +70,7 @@ $palette: (
   'error-muted-300'
 );
 
-$aliases: (
+$_aliases: (
   'content-main',
   'content-secondary',
   'content-action',
@@ -140,10 +140,10 @@ $aliases: (
 );
 
 @function color($name, $alpha: 1) {
-  @if index($aliases, $name) {
+  @if index($_aliases, $name) {
     @return rgba(var(--ods-color-#{$name}));
   }
-  @if index($palette, $name) {
+  @if index($_palette, $name) {
     @return rgba(var(--ods-color-#{$name}), #{$alpha});
   }
 

--- a/packages/core/src/helpers/font/font.scss
+++ b/packages/core/src/helpers/font/font.scss
@@ -1,7 +1,7 @@
 @use 'sass:map';
 @use 'sass:string';
 
-$allowed-combinations: (
+$_allowed-combinations: (
   '800-bold',
   '700-bold',
   '600-bold',
@@ -31,7 +31,7 @@ $allowed-combinations: (
   '200-mono'
 );
 
-$sizes: (
+$_sizes: (
   '800': (
     font-size: 3.375rem,
     line-height: 4rem,
@@ -66,7 +66,7 @@ $sizes: (
   ),
 );
 
-$types: (
+$_types: (
   'bold': (
     font-weight: 500,
   ),
@@ -85,7 +85,7 @@ $types: (
 );
 
 @mixin font($name) {
-  @if not index($allowed-combinations, $name) {
+  @if not index($_allowed-combinations, $name) {
     @error 'Font token not supported: #{$name}';
   }
 
@@ -95,22 +95,22 @@ $types: (
     $separator-index: string.index($name, '-');
 
     $size-key: string.slice($name, 1, $separator-index - 1);
-    $size-styles: map.get($sizes, $size-key);
+    $size-styles: map.get($_sizes, $size-key);
     $styles: map.merge($styles, $size-styles);
 
     $type-key: string.slice($name, $separator-index + 1);
-    $type-styles: map.get($types, $type-key);
+    $type-styles: map.get($_types, $type-key);
     $styles: map.merge($styles, $type-styles);
   }
 
-  font-family: get-or-default($styles, font-family, inherit);
-  font-size: get-or-default($styles, font-size, initial);
-  font-weight: get-or-default($styles, font-weight, initial);
-  line-height: get-or-default($styles, line-height, initial);
-  text-transform: get-or-default($styles, text-transform, none);
+  font-family: _get-or-default($styles, font-family, inherit);
+  font-size: _get-or-default($styles, font-size, initial);
+  font-weight: _get-or-default($styles, font-weight, initial);
+  line-height: _get-or-default($styles, line-height, initial);
+  text-transform: _get-or-default($styles, text-transform, none);
 }
 
-@function get-or-default($map, $key, $default) {
+@function _get-or-default($map, $key, $default) {
   @if map.has-key($map, $key) {
     @return map.get($map, $key);
   }

--- a/packages/core/src/helpers/space/space.scss
+++ b/packages/core/src/helpers/space/space.scss
@@ -1,18 +1,18 @@
-$allowed-floats: (2.5, 1.5, 0.5, 0.25, 0.125);
-$base: 8px;
+$_allowed-floats: (2.5, 1.5, 0.5, 0.25, 0.125);
+$_base: 8px;
 
 @function space($multiplier) {
-  @if not is-allowed($multiplier) {
-    @error '$multiplier must be an integer or (#{$allowed-floats})';
+  @if not _is-allowed($multiplier) {
+    @error '$multiplier must be an integer or (#{$_allowed-floats})';
   }
 
-  @return $multiplier * $base;
+  @return $multiplier * $_base;
 }
 
-@function is-allowed($multiplier) {
-  @return is-integer($multiplier) or index($allowed-floats, $multiplier);
+@function _is-allowed($multiplier) {
+  @return _is-integer($multiplier) or index($_allowed-floats, $multiplier);
 }
 
-@function is-integer($number) {
+@function _is-integer($number) {
   @return $number % 1 == 0;
 }

--- a/packages/core/src/mixins/with-focus.scss
+++ b/packages/core/src/mixins/with-focus.scss
@@ -1,27 +1,27 @@
 @use '../helpers';
 
-$allowed-types: ('action', 'negative');
+$_allowed-types: ('action', 'negative');
 
-$spread: 4px;
-$inner-size: 1px;
-$color-size: $spread - $inner-size;
+$_spread: 4px;
+$_inner-size: 1px;
+$_color-size: $_spread - $_inner-size;
 
-$max-border-width: $color-size; // when max - border used instead of color line
+$_max-border-width: $_color-size; // when max, border used instead of color line
 
 @mixin with-focus($type, $border-width: 0) {
-  @if not index($allowed-types, $type) {
-    @error '$type must be one of (#{$allowed-types})';
+  @if not index($_allowed-types, $type) {
+    @error '$type must be one of (#{$_allowed-types})';
   }
 
   @if type-of($border-width) != number {
     @error '$border-width must be a number';
   }
-  @if $border-width < 0 or $border-width > $max-border-width {
+  @if $border-width < 0 or $border-width > $_max-border-width {
     @error '$border-width must be between 0 and #{$max-border-width}';
   }
 
-  $inner-spread: $spread - $border-width;
-  $color-spread: $inner-spread - $inner-size;
+  $inner-spread: $_spread - $border-width;
+  $color-spread: $inner-spread - $_inner-size;
 
   $inner-line: inset 0 0 0 $inner-spread helpers.color('border-focus-inner');
   $color-line: inset 0 0 0 $color-spread helpers.color('border-#{$type}-focus');


### PR DESCRIPTION
## Purpose

In case of same variable names used across different helpers/mixins, they would be unable to be imported into same index, instead those variables should be private.

In Sass private variables can be prefixed either with `_` or `-`.

## Approach

Allowing `_` prefix for dollar variables and at functions, using such in core helpers and mixins.

## Testing

On Storybook.

## Risks

Breaks if someone would have been using those variables outside of Castor. However, because this is not official API we do not treat this as a breaking change.
