### PR TITLE
feat(core): allow space to be used with any number

### DIFF
--- a/packages/core/src/helpers/space/space.scss
+++ b/packages/core/src/helpers/space/space.scss
@@ -1,18 +1,9 @@
-$_allowed-floats: (2.5, 1.5, 0.5, 0.25, 0.125);
 $_base: 8px;
 
 @function space($multiplier) {
-  @if not _is-allowed($multiplier) {
-    @error '$multiplier must be an integer or (#{$_allowed-floats})';
+  @if type-of($multiplier) != number {
+    @error '$multiplier must be a number';
   }
 
   @return $multiplier * $_base;
-}
-
-@function _is-allowed($multiplier) {
-  @return _is-integer($multiplier) or index($_allowed-floats, $multiplier);
-}
-
-@function _is-integer($number) {
-  @return $number % 1 == 0;
 }

--- a/packages/core/src/helpers/space/space.spec.ts
+++ b/packages/core/src/helpers/space/space.spec.ts
@@ -2,21 +2,19 @@ import { describe, expect, it } from '@jest/globals';
 import { space } from './space';
 
 describe('space', () => {
-  it('should return the correct "multiplier * base" value', () => {
-    expect(space(1)).toBe('8px');
-  });
-
-  it('should allow (2.5, 1.5, 0.5, 0.25, 0.125)', () => {
-    expect(space(2.5)).toBe('20px');
-    expect(space(1.5)).toBe('12px');
-    expect(space(0.5)).toBe('4px');
+  it('should return the correct positive "multiplier * base" value', () => {
     expect(space(0.25)).toBe('2px');
-    expect(space(0.125)).toBe('1px');
+    expect(space(0.5)).toBe('4px');
+    expect(space(1)).toBe('8px');
+    expect(space(1.5)).toBe('12px');
+    expect(space(2.5)).toBe('20px');
   });
 
-  it('should throw for non integers or not in (2.5, 1.5, 0.5, 0.25, 0.125)', () => {
-    expect(() => space(0.75)).toThrowError(
-      '"multiplier" must be an integer or (2.5, 1.5, 0.5, 0.25, 0.125)'
-    );
+  it('should return the correct negative "multiplier * base" value', () => {
+    expect(space(-0.25)).toBe('-2px');
+    expect(space(-0.5)).toBe('-4px');
+    expect(space(-1)).toBe('-8px');
+    expect(space(-1.5)).toBe('-12px');
+    expect(space(-2.5)).toBe('-20px');
   });
 });

--- a/packages/core/src/helpers/space/space.ts
+++ b/packages/core/src/helpers/space/space.ts
@@ -1,8 +1,6 @@
 /**
  * Returns the `px` size of a multiplier of the base space.
  *
- * Only integers and (2.5, 1.5, 0.5, 0.25, 0.125) are supported.
- *
  * @param multiplier How much to multiply the base.
  *
  * @example
@@ -10,16 +8,7 @@
  * // '32px'
  */
 export function space(multiplier: number): string {
-  if (!isAllowed(multiplier))
-    throw new Error(`"multiplier" must be an integer or (${allowedFloats})`);
-
   return `${multiplier * base}px`;
 }
 
-const allowedFloats = new Set([2.5, 1.5, 0.5, 0.25, 0.125]);
-allowedFloats.toString = () => [...allowedFloats].join(', ');
-
 const base = 8;
-
-const isAllowed = (multiplier: number) =>
-  Number.isInteger(multiplier) || allowedFloats.has(multiplier);


### PR DESCRIPTION
## Purpose

To simplify using `space` there should be any number allowed to be used.

## Approach

Allowing any number to be used as multiplier for `space` helper.

## Testing

Unit tests, on Storybook.

## Risks

N/A
