### PR TITLE
docs: don't set "href" key when value is empty string

### DIFF
--- a/packages/react/src/components/button/button.react.stories.tsx
+++ b/packages/react/src/components/button/button.react.stories.tsx
@@ -27,7 +27,17 @@ export default {
   },
 } as Meta<ButtonProps>;
 
-export const Playground: Story<ButtonProps> = (props) => <Button {...props} />;
+export const Playground: Story<ButtonProps> = ({
+  href,
+  ...restProps
+}: ButtonProps & Pick<JSX.IntrinsicElements['a'], 'href'>) => (
+  <Button
+    {...{
+      ...restProps,
+      ...(href && { href }), // don't set "href" key when value is empty string
+    }}
+  />
+);
 
 export const Kind = storyOf(Button, 'kind', ['action', 'destructive']);
 Kind.argTypes = omit<ButtonProps>('kind', 'children');


### PR DESCRIPTION
## Purpose

Button component uses `<a>` tag when "href" prop is present.

A story starts with it being `undefined`, however when entering any value into "href" input on the story and then removing it, "href" prop becomes an empty string instead of previous `undefined` value, and this does not allow to revert component to use `<button>` tag so "disabled" prop is not working anymore.

## Approach

Only set "href" prop to component when it has a value.

## Testing

On Storybook.

## Risks

N/A
