### PR TITLE
docs: better describe textarea component "resize" variations

### DIFF
--- a/packages/react/src/components/textarea/textarea.react.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.react.stories.tsx
@@ -2,6 +2,14 @@ import { Textarea, TextareaProps } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, Story, storyOf } from '../../../../../docs';
 
+const resizes: readonly TextareaProps['resize'][] = [
+  'vertical',
+  'horizontal',
+  'both',
+  'none',
+];
+resizes.toString = () => resizes.map((value) => `"${value}"`).join('|');
+
 export default {
   title: 'React/Textarea',
   component: Textarea,
@@ -10,12 +18,14 @@ export default {
     placeholder: { control: 'text' },
     resize: {
       table: {
-        type: { summary: 'string' },
+        type: {
+          summary: resizes.toString(),
+        },
         defaultValue: { summary: 'vertical' },
       },
       control: {
-        type: 'select',
-        options: ['vertical', 'horizontal', 'both', 'none'],
+        type: 'radio',
+        options: resizes,
       },
     },
     rows: {
@@ -45,15 +55,10 @@ export const Playground: Story<TextareaProps> = (props: TextareaProps) => (
   <Textarea {...props} />
 );
 
-export const Resize = storyOf(
-  Textarea,
-  'resize',
-  ['vertical', 'horizontal', 'both', 'none'],
-  {
-    labelMode: 'prop',
-    labelProp: 'defaultValue',
-  }
-);
+export const Resize = storyOf(Textarea, 'resize', resizes, {
+  labelMode: 'prop',
+  labelProp: 'defaultValue',
+});
 Resize.argTypes = omit<TextareaProps>('resize');
 
 export const Invalid = storyOf(Textarea, 'invalid', [true, false], {


### PR DESCRIPTION
## Purpose

After [adding "resize" table options to Textarea component](https://github.com/onfido/castor/pull/157) it is now not aligned with other type description that allow only certain "resize" prop to be set:

<img width="995" alt="Screenshot 2021-01-12 at 11 39 17" src="https://user-images.githubusercontent.com/20243687/104297031-47315e00-54ba-11eb-95ff-9c2de93a00d2.png">

For example, on Button component we describe what "kind" prop can be set.

## Approach

Modify table options to describe available "resize" prop values:

<img width="994" alt="Screenshot 2021-01-12 at 11 36 59" src="https://user-images.githubusercontent.com/20243687/104297167-71831b80-54ba-11eb-8fa6-27dd8db5c284.png">

This also changes picker to "radio", same as used by default on Button component.

## Testing

On Storybook.

## Risks

Because this is not picked up from types by Storybook anymore (due to `withRef` wrapper usage), it needs to be manually aligned with any change made.
