### PR TITLE
fix(react): withRef component displayNames

### DIFF
--- a/packages/react/src/components/input/input.react.tsx
+++ b/packages/react/src/components/input/input.react.tsx
@@ -2,19 +2,19 @@ import { c, classy, InputProps as BaseProps, m } from '@onfido/castor';
 import React from 'react';
 import { withRef } from '../../utils';
 
-export const Input = withRef(
-  (
-    { type = 'text', invalid, className, ...restProps }: InputProps,
-    ref: InputProps['ref']
-  ): JSX.Element => (
+export const Input = withRef(function Input(
+  { type = 'text', invalid, className, ...restProps }: InputProps,
+  ref: InputProps['ref']
+): JSX.Element {
+  return (
     <input
       {...restProps}
       ref={ref}
       type={type}
       className={classy(c('input'), m({ invalid }), className)}
     />
-  )
-);
+  );
+});
 
 export type InputProps = BaseProps &
   Omit<JSX.IntrinsicElements['input'], 'children'>;

--- a/packages/react/src/components/input/input.react.tsx
+++ b/packages/react/src/components/input/input.react.tsx
@@ -2,19 +2,20 @@ import { c, classy, InputProps as BaseProps, m } from '@onfido/castor';
 import React from 'react';
 import { withRef } from '../../utils';
 
-export const Input = withRef(function Input(
-  { type = 'text', invalid, className, ...restProps }: InputProps,
-  ref: InputProps['ref']
-): JSX.Element {
-  return (
+export const Input = withRef(
+  (
+    { type = 'text', invalid, className, ...restProps }: InputProps,
+    ref: InputProps['ref']
+  ): JSX.Element => (
     <input
       {...restProps}
       ref={ref}
       type={type}
       className={classy(c('input'), m({ invalid }), className)}
     />
-  );
-});
+  )
+);
+Input.displayName = 'Input';
 
 export type InputProps = BaseProps &
   Omit<JSX.IntrinsicElements['input'], 'children'>;

--- a/packages/react/src/components/search/search.react.tsx
+++ b/packages/react/src/components/search/search.react.tsx
@@ -10,16 +10,17 @@ import { Input, InputProps } from '../input/input.react';
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Search = withRef(function Search(
-  { className, style, ...restProps }: SearchProps,
-  ref: SearchProps['ref']
-): JSX.Element {
-  return (
+export const Search = withRef(
+  (
+    { className, style, ...restProps }: SearchProps,
+    ref: SearchProps['ref']
+  ): JSX.Element => (
     <div className={classy(c('search'), className)} style={style}>
       <Input {...restProps} ref={ref} type="search" />
       <Icon name="search" />
     </div>
-  );
-});
+  )
+);
+Search.displayName = 'Search';
 
 export type SearchProps = Omit<InputProps, 'invalid' | 'type'>;

--- a/packages/react/src/components/search/search.react.tsx
+++ b/packages/react/src/components/search/search.react.tsx
@@ -10,16 +10,16 @@ import { Input, InputProps } from '../input/input.react';
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Search = withRef(
-  (
-    { className, style, ...restProps }: SearchProps,
-    ref: SearchProps['ref']
-  ): JSX.Element => (
+export const Search = withRef(function Search(
+  { className, style, ...restProps }: SearchProps,
+  ref: SearchProps['ref']
+): JSX.Element {
+  return (
     <div className={classy(c('search'), className)} style={style}>
       <Input {...restProps} ref={ref} type="search" />
       <Icon name="search" />
     </div>
-  )
-);
+  );
+});
 
 export type SearchProps = Omit<InputProps, 'invalid' | 'type'>;

--- a/packages/react/src/components/textarea/textarea.react.tsx
+++ b/packages/react/src/components/textarea/textarea.react.tsx
@@ -2,18 +2,18 @@ import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import React from 'react';
 import { withRef } from '../../utils';
 
-export const Textarea = withRef(
-  (
-    {
-      resize = 'vertical',
-      rows = 3,
-      invalid,
-      className,
-      style,
-      ...restProps
-    }: TextareaProps,
-    ref: TextareaProps['ref']
-  ): JSX.Element => (
+export const Textarea = withRef(function Textarea(
+  {
+    resize = 'vertical',
+    rows = 3,
+    invalid,
+    className,
+    style,
+    ...restProps
+  }: TextareaProps,
+  ref: TextareaProps['ref']
+): JSX.Element {
+  return (
     <textarea
       {...restProps}
       ref={ref}
@@ -21,8 +21,8 @@ export const Textarea = withRef(
       className={classy(c('textarea'), m({ invalid }), className)}
       style={{ ...style, resize }}
     />
-  )
-);
+  );
+});
 
 export type TextareaProps = BaseProps &
   Omit<JSX.IntrinsicElements['textarea'], 'children'>;

--- a/packages/react/src/components/textarea/textarea.react.tsx
+++ b/packages/react/src/components/textarea/textarea.react.tsx
@@ -2,18 +2,18 @@ import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import React from 'react';
 import { withRef } from '../../utils';
 
-export const Textarea = withRef(function Textarea(
-  {
-    resize = 'vertical',
-    rows = 3,
-    invalid,
-    className,
-    style,
-    ...restProps
-  }: TextareaProps,
-  ref: TextareaProps['ref']
-): JSX.Element {
-  return (
+export const Textarea = withRef(
+  (
+    {
+      resize = 'vertical',
+      rows = 3,
+      invalid,
+      className,
+      style,
+      ...restProps
+    }: TextareaProps,
+    ref: TextareaProps['ref']
+  ): JSX.Element => (
     <textarea
       {...restProps}
       ref={ref}
@@ -21,8 +21,9 @@ export const Textarea = withRef(function Textarea(
       className={classy(c('textarea'), m({ invalid }), className)}
       style={{ ...style, resize }}
     />
-  );
-});
+  )
+);
+Textarea.displayName = 'Textarea';
 
 export type TextareaProps = BaseProps &
   Omit<JSX.IntrinsicElements['textarea'], 'children'>;

--- a/packages/react/src/utils/withRef.ts
+++ b/packages/react/src/utils/withRef.ts
@@ -6,6 +6,10 @@ import { FC, forwardRef } from 'react';
  * @param component Component to `forwardRef`.
  */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-export const withRef = <C extends FC<any>>(component: C): C =>
+export const withRef = <C extends FC<any>>(component: C): C & Named =>
   forwardRef(component as any) as any;
 /* eslint-enable @typescript-eslint/no-explicit-any */
+
+interface Named {
+  displayName?: string;
+}


### PR DESCRIPTION
## Purpose

Closes https://github.com/onfido/castor/issues/151

## Approach

Explicitly name functions used inside `withRef` so that the function's name is used as `displayName`.

## Testing

Go to Storybook, select their stories, click show code, confirm it shows the component name.

## Risks

There's no way to guarantee `withRef` will be used with named functions in the future.
Anonymous functions will continue to have the same issue.
There is a lint rule for `forwardRed`, but then the types get all messed up (which `withRef` fixes).
