### PR TITLE
fix(react): add display name to radio component

### DIFF
--- a/packages/react/src/components/radio/radio.react.tsx
+++ b/packages/react/src/components/radio/radio.react.tsx
@@ -22,6 +22,7 @@ export const Radio = withRef(
     </label>
   )
 );
+Radio.displayName = 'Radio';
 
 export type RadioProps = BaseProps &
   Omit<JSX.IntrinsicElements['input'], 'type'>;


### PR DESCRIPTION
## Purpose

A [fix added display names](https://github.com/onfido/castor/pull/177) to React components that use `withRef` wrapper. However, Radio component did not have the fix applied.

## Approach

Add `displayName` to Radio component.

## Testing

On Storybook - component code examples should properly display the name of Radio component.

## Risks

N/A
