### PR TITLE
docs: improve component notes

### DIFF
--- a/packages/react/src/components/description/description.react.tsx
+++ b/packages/react/src/components/description/description.react.tsx
@@ -2,7 +2,7 @@ import { c, classy, DescriptionProps as BaseProps, m } from '@onfido/castor';
 import React from 'react';
 
 /**
- * @note Intended to be used within Radio component.
+ * Intended to be used within `Radio` component.
  */
 export const Description = ({
   disabled,

--- a/packages/react/src/components/icon/icon.react.tsx
+++ b/packages/react/src/components/icon/icon.react.tsx
@@ -2,8 +2,8 @@ import { c, classy, color, IconProps as BaseProps } from '@onfido/castor';
 import React from 'react';
 
 /**
- * @note `Icon` requires `Icons` (SVG sprite) to be included in your app.
- * If you wish to use individual inlined SVGs, use generated components from
+ * `Icon` requires `Icons` (SVG sprite) to be included in your app. If you wish
+ * to use individual inlined SVGs, use generated components from
  * `@onfido/castor-icons` instead.
  *
  * https://github.com/onfido/castor-icons

--- a/packages/react/src/components/search/search.react.tsx
+++ b/packages/react/src/components/search/search.react.tsx
@@ -5,8 +5,8 @@ import { withRef } from '../../utils';
 import { Input, InputProps } from '../input/input.react';
 
 /**
- * @note `Search` uses an `Icon` that requires `Icons` (SVG sprite) to be
- * included in your app.
+ * `Search` uses an `Icon` that requires `Icons` (SVG sprite) to be included in
+ * your app.
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */


### PR DESCRIPTION
## Purpose

To make sure component notes are aligned and also visible on Storybook.

## Approach

Removing usage of `@note` as then notes are not visible on Storybook, also making sure component names are quoted to align all component notes.

## Testing

On Storybook mainly.

## Risks

N/A
