### PR TITLE
fix(core): correct "neutral-600" color due to accessibility

### DIFF
--- a/packages/core/src/theme/tokens.json
+++ b/packages/core/src/theme/tokens.json
@@ -7,7 +7,7 @@
     "color-neutral-900": "30, 30, 36",
     "color-neutral-800": "43, 45, 51",
     "color-neutral-700": "99, 102, 112",
-    "color-neutral-600": "162, 168, 179",
+    "color-neutral-600": "130, 136, 147",
     "color-neutral-500": "180, 186, 197",
     "color-neutral-400": "213, 218, 224",
     "color-neutral-300": "233, 236, 240",


### PR DESCRIPTION
## Purpose

WCAG guideline that states input borders need to have a 3:1 contrast ratio, so "neutral-600" (used
for input borders) must be adjusted accordingly.

## Approach

Change "neutral-600" color token value.

## Testing

On Storybook, inspecting input components.

## Risks

N/A
