### PR TITLE
fix(core): correct input/action border color on night theme

### DIFF
--- a/packages/core/src/theme/themes/night.scss
+++ b/packages/core/src/theme/themes/night.scss
@@ -53,10 +53,10 @@
     --ods-color-background-inverse-action: var(--ods-color-primary-500), 1;
 
     --ods-color-border-separator: var(--ods-color-neutral-900), 1;
-    --ods-color-border-input: var(--ods-color-neutral-700), 1;
-    --ods-color-border-input-hover: var(--ods-color-neutral-600), 1;
-    --ods-color-border-action: var(--ods-color-neutral-700), 1;
-    --ods-color-border-action-hover: var(--ods-color-neutral-600), 1;
+    --ods-color-border-input: var(--ods-color-neutral-600), 1;
+    --ods-color-border-input-hover: var(--ods-color-neutral-500), 1;
+    --ods-color-border-action: var(--ods-color-neutral-600), 1;
+    --ods-color-border-action-hover: var(--ods-color-neutral-500), 1;
     --ods-color-border-action-subtle: var(--ods-color-primary-muted-600), 1;
     --ods-color-border-disabled: var(--ods-color-neutral-700), 1;
     --ods-color-border-negative: var(--ods-color-error-400), 1;


### PR DESCRIPTION
## Purpose

WCAG guideline that states input borders need to have a 3:1 contrast ratio, input and action border colors must be adjusted on a night theme.

## Approach

Adjust input/action border color on a night theme.

## Testing

On Storybook.

## Risks

N/A
