### PR TITLE
build: automatically sort imports

### DIFF
--- a/examples/react-emotion-ts-parcel/src/index.tsx
+++ b/examples/react-emotion-ts-parcel/src/index.tsx
@@ -1,7 +1,7 @@
+import '@onfido/castor/dist/castor.css';
+import '@onfido/castor/dist/themes/day.css';
 import React from 'react';
 import { render } from 'react-dom';
 import { App } from './App';
-import '@onfido/castor/dist/castor.css';
-import '@onfido/castor/dist/themes/day.css';
 
 render(<App />, document.getElementById('root'));

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lint-staged": "^10.5.3",
     "optimist": "^0.6.1",
     "prettier": "^2.2.1",
+    "prettier-plugin-organize-imports": "^1.1.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "sass": "^1.32.4",

--- a/scripts/generate-tokens.ts
+++ b/scripts/generate-tokens.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync } from 'fs';
-import { resolve, join } from 'path';
+import { join, resolve } from 'path';
 import { convert, registerFormat } from 'theo';
 
 const rootPath = resolve('.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -12840,6 +12840,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
+prettier-plugin-organize-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-1.1.1.tgz#7f1ac1a13d4d1752dc16881894dde1c10ccbf3c0"
+  integrity sha512-rFA1lnek1FYkMGthm4xBKME41qUKItTovuo24bCGZu/Vu1n3gW71UPLAkIdwewwkZCe29gRVweSOPXvAdckFuw==
+
 prettier@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"


### PR DESCRIPTION
## Purpose

Automatically organise imports like VSCode does.

## Approach

Temporarily use [prettier-plugin-organize-imports](https://github.com/simonhaenisch/prettier-plugin-organize-imports) 
Upside is that it reuses TypeScripts runtime so it's exactly the same format.
Downsides listed on Risks.

Other options include:
- ESLint's rule `sort-imports` can only sort paths, not members
- [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import) works well except for import members, uses alias instead of source name, and can't be configured at that level
- [eslint-plugin-simple-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort) works well except for unnamed imports, always sorts them first regardless of path, and can be configured but has some logic that'd need to be changed.
  Issue has been opened https://github.com/lydell/eslint-plugin-simple-import-sort/issues/65

## Testing

- `npm run lint` and check that no file is an offender
- change import order on any file then create a commit, it should sort them automatically

## Risks

- It is against Prettier's philosophy to alter the AST (Abstract Syntax Tree) as [prettier-plugin-organize-imports](https://github.com/simonhaenisch/prettier-plugin-organize-imports/blob/master/readme.md#rationale) itself states
- Because it is not a lint rule we don't get squiggly red lines with text editor ESLint extensions