### PR TITLE
fix(core): input and textarea borders on focus

### DIFF
--- a/packages/core/src/components/input/input.scss
+++ b/packages/core/src/components/input/input.scss
@@ -1,44 +1,7 @@
-@use '../../helpers';
 @use '../../mixins';
 
 @mixin Input() {
-  $border-width: 1px;
-
   .ods-input {
-    @include helpers.font('300-regular');
-    @include mixins.with-inner-focus('action', $border-width);
-
-    background-color: helpers.color('background-input');
-    border: $border-width solid helpers.color('border-input');
-    border-radius: helpers.border-radius('medium');
-    box-sizing: border-box;
-    color: helpers.color('content-main');
-    padding: helpers.space(1.5) - $border-width helpers.space(2) - $border-width;
-    width: helpers.space(50);
-
-    &::placeholder {
-      color: helpers.color('content-placeholder');
-    }
-
-    &:hover {
-      border-color: helpers.color('border-input-hover');
-    }
-
-    &.-invalid {
-      @include mixins.with-inner-focus('negative', $border-width);
-
-      border-color: helpers.color('border-negative');
-      color: helpers.color('content-negative');
-    }
-
-    &:disabled {
-      background-color: helpers.color('background-disabled');
-      border-color: helpers.color('border-disabled');
-      color: helpers.color('content-disabled');
-
-      &::placeholder {
-        color: inherit;
-      }
-    }
+    @include mixins.as-text-input();
   }
 }

--- a/packages/core/src/components/textarea/textarea.scss
+++ b/packages/core/src/components/textarea/textarea.scss
@@ -1,45 +1,9 @@
-@use '../../helpers';
 @use '../../mixins';
 
 @mixin Textarea() {
-  $border-width: 1px;
-
   .ods-textarea {
-    @include helpers.font('300-regular');
-    @include mixins.with-inner-focus('action', $border-width);
+    @include mixins.as-text-input();
 
-    background-color: helpers.color('background-input');
-    border: $border-width solid helpers.color('border-input');
-    border-radius: helpers.border-radius('medium');
-    box-sizing: border-box;
-    color: helpers.color('content-main');
-    padding: helpers.space(1.5) - $border-width helpers.space(2) - $border-width;
     resize: vertical;
-    width: helpers.space(50);
-
-    &::placeholder {
-      color: helpers.color('content-placeholder');
-    }
-
-    &:hover {
-      border-color: helpers.color('border-input-hover');
-    }
-
-    &.-invalid {
-      @include mixins.with-inner-focus('negative', $border-width);
-
-      border-color: helpers.color('border-negative');
-      color: helpers.color('content-negative');
-    }
-
-    &:disabled {
-      background-color: helpers.color('background-disabled');
-      border-color: helpers.color('border-disabled');
-      color: helpers.color('content-disabled');
-
-      &::placeholder {
-        color: inherit;
-      }
-    }
   }
 }

--- a/packages/core/src/mixins/as-text-input.scss
+++ b/packages/core/src/mixins/as-text-input.scss
@@ -1,0 +1,45 @@
+@use '../helpers';
+@use './with-inner-focus' as mixins;
+
+@mixin as-text-input() {
+  @include helpers.font('300-regular');
+
+  $border-width: 1px;
+
+  background-color: helpers.color('background-input');
+  border: $border-width solid helpers.color('border-input');
+  border-radius: helpers.border-radius('medium');
+  box-sizing: border-box;
+  color: helpers.color('content-main');
+  padding: helpers.space(1.5) - $border-width helpers.space(2) - $border-width;
+  width: helpers.space(50);
+
+  &::placeholder {
+    color: helpers.color('content-placeholder');
+  }
+
+  &:hover {
+    border-color: helpers.color('border-input-hover');
+  }
+
+  // needs to be applied between [hover] and invalid states
+  // stylelint-disable-next-line order/order
+  @include mixins.with-inner-focus('action', $border-width);
+
+  &.-invalid {
+    @include mixins.with-inner-focus('negative', $border-width);
+
+    border-color: helpers.color('border-negative');
+    color: helpers.color('content-negative');
+  }
+
+  &:disabled {
+    background-color: helpers.color('background-disabled');
+    border-color: helpers.color('border-disabled');
+    color: helpers.color('content-disabled');
+
+    &::placeholder {
+      color: inherit;
+    }
+  }
+}

--- a/packages/core/src/mixins/index.scss
+++ b/packages/core/src/mixins/index.scss
@@ -1,3 +1,4 @@
+@forward './as-text-input';
 @forward './interactive';
 @forward './square';
 @forward './with-inner-focus';


### PR DESCRIPTION
## Purpose

Closes #207 

## Approach

Refactors their styles to be shared in a mixin `as-text-input`.
That mixin also fixes the border specificity issue,
by applying it between `:hover` and `.-invalid`,
which requires a `stylelint` line disable.

## Testing

Visually check the borders on focus.

## Risks

None.
