### PR TITLE
fix: selectors applied conditionally

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,15 +11,9 @@
     "scss/no-global-function-names": true,
     "order/order": [
       [
-        {
-          "type": "at-rule",
-          "name": "include"
-        },
-        {
-          "type": "at-rule",
-          "name": "extend"
-        },
         "dollar-variables",
+        { "type": "at-rule", "name": "include" },
+        { "type": "at-rule", "name": "extend" },
         "custom-properties",
         "declarations",
         "rules"

--- a/packages/core/src/mixins/as-text-input.scss
+++ b/packages/core/src/mixins/as-text-input.scss
@@ -2,9 +2,9 @@
 @use './with-inner-focus' as mixins;
 
 @mixin as-text-input() {
-  @include helpers.font('300-regular');
-
   $border-width: 1px;
+
+  @include helpers.font('300-regular');
 
   background-color: helpers.color('background-input');
   border: $border-width solid helpers.color('border-input');

--- a/packages/core/src/mixins/index.scss
+++ b/packages/core/src/mixins/index.scss
@@ -3,3 +3,4 @@
 @forward './square';
 @forward './with-inner-focus';
 @forward './with-outer-focus';
+@forward './wrap-if';

--- a/packages/core/src/mixins/interactive.scss
+++ b/packages/core/src/mixins/interactive.scss
@@ -1,5 +1,7 @@
+@use './wrap-if' as mixins;
+
 @mixin interactive($target: null) {
-  #{if($target, $target, '&')} {
+  @include mixins.wrap-if($target) {
     cursor: pointer;
     user-select: none;
   }

--- a/packages/core/src/mixins/with-inner-focus.scss
+++ b/packages/core/src/mixins/with-inner-focus.scss
@@ -1,4 +1,5 @@
 @use '../helpers';
+@use './wrap-if' as mixins;
 
 $_allowed-types: ('action', 'negative');
 
@@ -26,7 +27,7 @@ $_max-border-width: $_color-size; // when max, border used instead of color line
   $inner-line: inset 0 0 0 $inner-spread helpers.color('border-focus-inner');
   $color-line: inset 0 0 0 $color-spread helpers.color('border-#{$type}-focus');
 
-  #{if($target, $target, '&')} {
+  @include mixins.wrap-if($target) {
     outline: none;
   }
 

--- a/packages/core/src/mixins/with-outer-focus.scss
+++ b/packages/core/src/mixins/with-outer-focus.scss
@@ -1,4 +1,5 @@
 @use '../helpers';
+@use './wrap-if' as mixins;
 
 $_allowed-types: ('action', 'negative');
 
@@ -14,7 +15,7 @@ $_inner-spread: $_color-spread - $_color-size;
   $color-line: 0 0 0 $_color-spread helpers.color('border-#{$type}-focus');
   $inner-line: 0 0 0 $_inner-spread helpers.color('border-focus-inner');
 
-  #{if($target, $target, '&')} {
+  @include mixins.wrap-if($target) {
     outline: none;
   }
 

--- a/packages/core/src/mixins/wrap-if.scss
+++ b/packages/core/src/mixins/wrap-if.scss
@@ -1,0 +1,9 @@
+@mixin wrap-if($selector) {
+  @if not $selector {
+    @content;
+  } @else {
+    #{$selector} {
+      @content;
+    }
+  }
+}

--- a/packages/core/src/theme/theme.scss
+++ b/packages/core/src/theme/theme.scss
@@ -1,4 +1,5 @@
 @use 'sass:list';
+@use '../mixins';
 @use './tokens' as castor;
 
 // ...$types: 'class' | 'raw';
@@ -6,9 +7,9 @@
   $class: list.index($types, 'class');
   $raw: list.index($types, 'raw');
 
-  $selector: if($class, '.castor-theme--#{$name}', '&');
+  $selector: if($class, '.castor-theme--#{$name}', null);
 
-  #{$selector} {
+  @include mixins.wrap-if($selector) {
     @if not $raw {
       @include castor.tokens();
     }


### PR DESCRIPTION
## Purpose

Sass' `&` will output the selector twice,
which is why the linter disallows it,
and our conditional selectors should account for that.

![image](https://user-images.githubusercontent.com/18623773/105177952-4f734400-5b1f-11eb-8c6a-b4862f0f1793.png)

## Approach

Apply with `@if` instead of function `if` which allows for better content control.
Create mixin for shareability.

## Testing

Check output CSS.

![image](https://user-images.githubusercontent.com/18623773/105178202-a37e2880-5b1f-11eb-9cc2-4de6c84be53e.png)

## Risks

Reorders stylelint rule, `@include` before `$variable`, which honestly is a better separation and allows local variables to be used in mixins.