### PR TITLE
ci: deploy with single commit, don't keep history

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,3 +39,4 @@ jobs:
           BRANCH: gh-pages
           FOLDER: public
           CLEAN: true
+          SINGLE_COMMIT: true


### PR DESCRIPTION
## Purpose

Storybook is deployed to GitHub Pages via [GitHub Actions](https://github.com/JamesIves/github-pages-deploy-action), however a commit history is kept for the branch that is not needed.

Following https://github.com/onfido/castor-icons/pull/71.

## Approach

Use `SINGLE_COMMIT` as [described in an action used](https://github.com/JamesIves/github-pages-deploy-action#optional-choices) to force-push to a target branch, this will not keep a deployment history.

## Testing

Only once this gets merged to `main`.

## Risks

N/A
