### PR TITLE
build(examples): correctly start webpack

### DIFF
--- a/examples/react-scss-js-webpack/package.json
+++ b/examples/react-scss-js-webpack/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.html",
   "scripts": {
     "build": "webpack --mode production",
-    "start": "webpack-dev-server --mode development --open --hot",
+    "start": "webpack serve --mode development --open --hot",
     "test": "es-check --module es5 ./dist/*.js"
   },
   "dependencies": {


### PR DESCRIPTION
## Purpose

webpack can no longer start (probably after some version upgrade):

<img width="915" alt="Screenshot 2021-01-21 at 10 53 46" src="https://user-images.githubusercontent.com/20243687/105328038-869d3000-5bc7-11eb-893c-59e7182a894a.png">

## Approach

Use `webpack serve` [as suggested](https://github.com/webpack/webpack-dev-server/issues/2424#issuecomment-581319104).

## Testing

Tested locally.

## Risks

N/A
