### PR TITLE
chore: use any @onfido/castor-icons version

### DIFF
--- a/examples/custom-themes/package.json
+++ b/examples/custom-themes/package.json
@@ -8,7 +8,7 @@
     "start": "parcel src/index.html --open"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0"
+    "@onfido/castor-icons": "*"
   },
   "devDependencies": {
     "autoprefixer": "^9.8.6",

--- a/examples/html-css-js-parcel/package.json
+++ b/examples/html-css-js-parcel/package.json
@@ -8,7 +8,7 @@
     "start": "parcel src/index.html --open"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0"
+    "@onfido/castor-icons": "*"
   },
   "devDependencies": {
     "autoprefixer": "^9.8.6",

--- a/examples/html-css-js/package.json
+++ b/examples/html-css-js/package.json
@@ -10,7 +10,7 @@
     "start": "yarn copy && http-server -p 1111 -o"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0"
+    "@onfido/castor-icons": "*"
   },
   "devDependencies": {
     "concurrently": "^5.3.0",

--- a/examples/html-css/package.json
+++ b/examples/html-css/package.json
@@ -10,7 +10,7 @@
     "start": "yarn copy && http-server -p 1111 -o"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0"
+    "@onfido/castor-icons": "*"
   },
   "devDependencies": {
     "concurrently": "^5.3.0",

--- a/examples/html-scss-ts-parcel/package.json
+++ b/examples/html-scss-ts-parcel/package.json
@@ -8,7 +8,7 @@
     "start": "parcel src/index.html --open"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0"
+    "@onfido/castor-icons": "*"
   },
   "devDependencies": {
     "autoprefixer": "^9.8.6",

--- a/examples/react-emotion-ts-parcel/package.json
+++ b/examples/react-emotion-ts-parcel/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@emotion/core": "^11.0.0",
     "@emotion/styled": "^10.0.27",
-    "@onfido/castor-icons": "^1.2.0",
+    "@onfido/castor-icons": "*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/examples/react-scss-js-webpack/package.json
+++ b/examples/react-scss-js-webpack/package.json
@@ -9,7 +9,7 @@
     "test": "es-check --module es5 ./dist/*.js"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0",
+    "@onfido/castor-icons": "*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/examples/react-scss-ts-parcel/package.json
+++ b/examples/react-scss-ts-parcel/package.json
@@ -8,7 +8,7 @@
     "start": "parcel src/index.html --open"
   },
   "dependencies": {
-    "@onfido/castor-icons": "^1.2.0",
+    "@onfido/castor-icons": "*",
     "react": "^17.0.1",
     "react-dom": "^17.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@onfido/castor-icons": "^1.2.0",
+    "@onfido/castor-icons": "*",
     "@storybook/addon-a11y": "^6.1.14",
     "@storybook/addon-controls": "^6.1.14",
     "@storybook/addon-docs": "^6.1.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,10 +1720,10 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@onfido/castor-icons@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@onfido/castor-icons/-/castor-icons-1.2.0.tgz#269abd74e863a92620e84355d13c016333fe249d"
-  integrity sha512-I/LQKwQwE1Uyb+Uhml9AoiXZeLCZL/wuvDVQ3jdOmvj4RNAvp2O9alFmqcyghQFGqtTxFIHza9jpDbTLjdQ0Uw==
+"@onfido/castor-icons@*":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@onfido/castor-icons/-/castor-icons-2.0.0.tgz#ac25af5c5c791c593860c107e6ba8851c0e98cce"
+  integrity sha512-/YxAi7zTPfW1qhPsi82ytWXwucIVqu4E1sZmVn3keJvZN4gM0adyyOB3412oaG6gT26Tqlxwmz7gJ9Vehv8/8Q==
 
 "@open-wc/building-utils@^2.18.3":
   version "2.18.3"


### PR DESCRIPTION
## Purpose

Dependabot does not currently upgrade majors of `@onfido/castor-icons`, however we actually can and need to have always the latest.

## Approach

Allow to use _any_ version of `@onfido/castor-icons`.

This also upgrades to the latest.

## Testing

After next major release of `@onfido/castor-icons` Dependabot should open a PR to upgrade.

## Risks

Not entirely sure if Dependabot won't change the `*` indicating _any_ version.
