### PR TITLE
refactor(core): use sass:list built-in module

### DIFF
--- a/packages/core/src/helpers/border-radius/border-radius.scss
+++ b/packages/core/src/helpers/border-radius/border-radius.scss
@@ -1,7 +1,9 @@
+@use 'sass:list';
+
 $_allowed-sizes: ('small', 'medium', 'large', 'full');
 
 @function border-radius($size) {
-  @if not index($_allowed-sizes, $size) {
+  @if not list.index($_allowed-sizes, $size) {
     @error '$size must be one of (#{$_allowed-sizes})';
   }
 

--- a/packages/core/src/helpers/color/color.scss
+++ b/packages/core/src/helpers/color/color.scss
@@ -1,3 +1,5 @@
+@use 'sass:list';
+
 $_palette: (
   'neutral-900',
   'neutral-800',
@@ -140,10 +142,10 @@ $_aliases: (
 );
 
 @function color($name, $alpha: 1) {
-  @if index($_aliases, $name) {
+  @if list.index($_aliases, $name) {
     @return rgba(var(--ods-color-#{$name}));
   }
-  @if index($_palette, $name) {
+  @if list.index($_palette, $name) {
     @return rgba(var(--ods-color-#{$name}), #{$alpha});
   }
 

--- a/packages/core/src/helpers/font/font.scss
+++ b/packages/core/src/helpers/font/font.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use 'sass:map';
 @use 'sass:string';
 
@@ -85,7 +86,7 @@ $_types: (
 );
 
 @mixin font($name) {
-  @if not index($_allowed-combinations, $name) {
+  @if not list.index($_allowed-combinations, $name) {
     @error 'Font token not supported: #{$name}';
   }
 

--- a/packages/core/src/mixins/with-inner-focus.scss
+++ b/packages/core/src/mixins/with-inner-focus.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../helpers';
 @use './wrap-if' as mixins;
 
@@ -10,7 +11,7 @@ $_color-size: $_spread - $_inner-size;
 $_max-border-width: $_color-size; // when max, border used instead of color line
 
 @mixin with-inner-focus($type, $border-width: 0, $target: null) {
-  @if not index($_allowed-types, $type) {
+  @if not list.index($_allowed-types, $type) {
     @error '$type must be one of (#{$_allowed-types})';
   }
 

--- a/packages/core/src/mixins/with-outer-focus.scss
+++ b/packages/core/src/mixins/with-outer-focus.scss
@@ -1,3 +1,4 @@
+@use 'sass:list';
 @use '../helpers';
 @use './wrap-if' as mixins;
 
@@ -8,7 +9,7 @@ $_color-size: 2px;
 $_inner-spread: $_color-spread - $_color-size;
 
 @mixin with-outer-focus($type, $target: null) {
-  @if not index($_allowed-types, $type) {
+  @if not list.index($_allowed-types, $type) {
     @error '$type must be one of (#{$_allowed-types})';
   }
 


### PR DESCRIPTION
## Purpose

Always use built-in Sass modules.

## Approach

Use `sass:list`  module instead of global function `index`.

## Testing

Workflow build should pass.

Unfortunetly, this is not enabled [on `no-global-function-names`stylelint rule](https://github.com/kristerkari/stylelint-scss/blob/deb3e6bbe2d4a526412eff9b60b9ca00192e05ff/src/rules/no-global-function-names/README.md), maybe because it's not part of official [full list of disallowed names](https://github.com/sass/sass/blob/master/accepted/module-system.md#built-in-modules-1).

## Risks

Nothing restricts from still using global `index`.
