### PR TITLE
feat(core)!: do not distribute individual component css files

### DIFF
--- a/packages/core/style/components/button.scss
+++ b/packages/core/style/components/button.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/button.css
-@use '../../src/components';
-
-@include components.Button();

--- a/packages/core/style/components/helper-text.scss
+++ b/packages/core/style/components/helper-text.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/helper-text.css
-@use '../../src/components';
-
-@include components.HelperText();

--- a/packages/core/style/components/icon.scss
+++ b/packages/core/style/components/icon.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/icon.css
-@use '../../src/components';
-
-@include components.Icon();

--- a/packages/core/style/components/input.scss
+++ b/packages/core/style/components/input.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/input.css
-@use '../../src/components';
-
-@include components.Input();

--- a/packages/core/style/components/radio.scss
+++ b/packages/core/style/components/radio.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/radio.css
-@use '../../src/components';
-
-@include components.Radio();

--- a/packages/core/style/components/search.scss
+++ b/packages/core/style/components/search.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/search.css
-@use '../../src/components';
-
-@include components.Search();

--- a/packages/core/style/components/textarea.scss
+++ b/packages/core/style/components/textarea.scss
@@ -1,4 +1,0 @@
-// this file will generate ./dist/components/textarea.css
-@use '../../src/components';
-
-@include components.Textarea();


### PR DESCRIPTION
## Purpose

For CSS build individual components will not be distributed, instead Sass is recommended to be used,
or dead code should be eliminated from "castor.css" file.

## Approach

Remove generation of individual component CSS files for distribution.

## Testing

On local build.

## Risks

This is a breaking change - indicating with a note.
