### PR TITLE
fix: correct indicator container border radius to "large"

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -48,7 +48,7 @@
 
   .ods-input-indicator {
     border: 1px solid transparent;
-    border-radius: helpers.border-radius('medium');
+    border-radius: helpers.border-radius('large');
     bottom: 0;
     left: 0;
     padding: $padding;


### PR DESCRIPTION
## Purpose

As per design border radius of an `IndicatorComponent` should be 8px that is "large" token.

## Approach

Switch from "medium" token to "large".

## Testing

On Storybook visually.

## Risks

N/A
