### PR TITLE
fix: use "gap" with grid

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -14,8 +14,9 @@
     border: $border-width solid transparent;
     border-radius: helpers.border-radius('medium');
     box-sizing: border-box;
-    display: inline-flex;
+    display: inline-grid;
     gap: helpers.space(1);
+    grid-auto-flow: column;
     justify-content: center;
     padding: helpers.space(1.5) - $border-width helpers.space(3) - $border-width;
     position: relative;

--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -10,13 +10,14 @@
     @include helpers.font('300-regular');
 
     color: helpers.color('content-main');
-    display: inline-flex;
+    display: inline-grid;
     gap: $padding;
+    grid-auto-flow: column;
     padding: $padding;
     position: relative;
 
     &.-bordered {
-      display: flex;
+      display: grid;
     }
   }
 

--- a/packages/react/src/components/button/button.react.stories.tsx
+++ b/packages/react/src/components/button/button.react.stories.tsx
@@ -70,8 +70,9 @@ export const WithIcon = ({
 }: ButtonWithIconProps) => (
   <div
     style={{
-      display: 'flex',
+      display: 'inline-grid',
       gap: space(1),
+      gridAutoFlow: 'column',
     }}
   >
     <Button {...restButtonProps}>


### PR DESCRIPTION
## Purpose

Using "gap" with Flexbox layout is not supported on iOS Safari, instead Grid layout is to be used.

## Approach

Use "grid" instead of "flex" (incl. "inline").

## Testing

On iOS Safari, and regular browser(s).

## Risks

N/A
