### PR TITLE
build: bump "core" as peer dependency

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,12 @@
   },
   "overrides": [
     {
+      "files": ["*.cjs"],
+      "rules": {
+        "@typescript-eslint/no-var-requires": "off"
+      }
+    },
+    {
       "files": ["*.spec.ts{,x}"],
       "rules": {
         "@typescript-eslint/no-empty-function": "off",

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -10,6 +10,10 @@
     "examples/react-scss-ts-parcel/package.json",
     "packages/core/package.json",
     "packages/react/package.json",
+    {
+      "filename": "packages/react/package.json",
+      "updater": "scripts/bump-core-peer-dependency.cjs"
+    },
     "package.json"
   ],
   "scripts": {

--- a/scripts/bump-core-peer-dependency.cjs
+++ b/scripts/bump-core-peer-dependency.cjs
@@ -1,0 +1,18 @@
+// can't be `bump-core-peer-dependency.ts` as it is invoked by
+// `standard-version` as a custom updater
+
+const detectIndent = require('detect-indent');
+const detectNewline = require('detect-newline');
+const stringifyPackage = require('stringify-package');
+
+module.exports.readVersion = function (contents) {
+  return JSON.parse(contents).peerDependencies['@onfido/castor'];
+};
+
+module.exports.writeVersion = function (contents, version) {
+  const json = JSON.parse(contents);
+  const indent = detectIndent(contents).indent;
+  const newline = detectNewline(contents);
+  json.peerDependencies['@onfido/castor'] = version;
+  return stringifyPackage(json, indent, newline);
+};


### PR DESCRIPTION
## Purpose

When bumping a version, also bump "core" as peer dependency, in current case only "react" package.

## Approach

Use a [custom updater for `standard-version`](https://github.com/conventional-changelog/standard-version#can-i-use-standard-version-for-additional-metadata-files-languages-or-version-files) to bump `@onfido/castor` as a peer dependency of `@onfido/castor-react`.

Unfortunetly, as the script is invoked by `standard-version` itself, I cannot use TypeScript here.

## Testing

`yarn release --dry-run`

<img width="653" alt="Screenshot 2021-01-27 at 15 28 04" src="https://user-images.githubusercontent.com/20243687/105998147-3da41a80-60a4-11eb-8d57-a6b7b860e121.png">

## Risks

N/A
