### PR TITLE
refactor(react): define <label> props type individually

### DIFF
--- a/packages/react/src/internal/indicator-container/indicator-container.tsx
+++ b/packages/react/src/internal/indicator-container/indicator-container.tsx
@@ -23,9 +23,11 @@ export const IndicatorContainer = ({
 );
 
 export type IndicatorContainerProps = BaseProps &
-  Omit<JSX.IntrinsicElements['label'], 'children'> & {
+  Omit<LabelElementProps, 'children'> & {
     children: {
-      children: JSX.IntrinsicElements['label']['children'];
+      children: LabelElementProps['children'];
       input: JSX.IntrinsicElements['input'];
     };
   };
+
+type LabelElementProps = JSX.IntrinsicElements['label'];


### PR DESCRIPTION
## Purpose

Define type for `<label>` element props once, then reuse.

## Approach

Define individual type `LabelElementProps`.

## Testing

N/A

## Risks

N/A
