### PR TITLE
docs(react): improve example with a fragment

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -29,10 +29,12 @@ import { Button } from '@onfido/castor-react';
 Then use within your JSX app. For example, as a "destructive" kind:
 
 ```jsx
+import React, { Fragment } from 'react';
+
 const App = () => (
-  <>
+  <Fragment>
     <Button kind="destructive">Destructive Button</Button>
-  </>
+  </Fragment>
 );
 ```
 


### PR DESCRIPTION
## Purpose

React `Fragment` is not properly styled when on GitHub docs.

## Approach

Instead of shorthand using full `<Fragment />` component. Also, showing inclusion of React itself in examples.

Same as it was [done on Castor Icons](https://github.com/onfido/castor-icons/pull/64).

## Testing

On GitHub itself.

## Risks

N/A
