### PR TITLE
docs(react): inform to include "icons" sprite

### DIFF
--- a/docs/_react/intro.story.tsx
+++ b/docs/_react/intro.story.tsx
@@ -32,5 +32,24 @@ export const Intro = () => (
       format
       dark
     />
+    <p>
+      Then (only once) inline the <code>Icons</code> SVG sprite in your app:
+    </p>
+    <Source
+      language="jsx"
+      code={`
+        import { Icons } from '@onfido/castor-icons';
+        import React, { Fragment } from 'react';
+        
+        const App = () => (
+          <Fragment>
+            <Icons />
+            {/* ...anything else e.g. app routes */}
+          </Fragment>
+        );
+      `}
+      format
+      dark
+    />
   </>
 );

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -18,6 +18,20 @@ If you plan to use Icon component, also install [Castor Icons](https://github.co
 npm install @onfido/castor-icons
 ```
 
+Then (only once) inline the SVG sprite in your app:
+
+```jsx
+import { Icons } from '@onfido/castor-icons';
+import React, { Fragment } from 'react';
+
+const App = () => (
+  <Fragment>
+    <Icons />
+    {/* ...anything else e.g. app routes */}
+  </Fragment>
+);
+```
+
 ## Use components
 
 Include any Castor component and use it within JSX directly.


### PR DESCRIPTION
## Purpose

Make it clear to include `Icons` SVG sprite when using React `Icon` component.

## Approach

Add instructions both on README ("react" package) and Storybook (React section).

## Testing

On GitLab itself, then on Storybook preview.

## Risks

N/A
