### PR TITLE
docs: improve installation instructions of icons on storybook

### DIFF
--- a/docs/_core/intro.story.tsx
+++ b/docs/_core/intro.story.tsx
@@ -10,23 +10,23 @@ export const Intro = () => (
 
     <h2>Install</h2>
     <p>
-      You can install with <code>npm</code>:
+      You can install with <code>npm</code> CLI tool:
     </p>
     <Source
       language="bash"
       code={`
-        npm install @onfido/castor @onfido/castor-icons
+        npm install @onfido/castor
       `}
       format
       dark
     />
     <p>
-      Or add with <code>Yarn</code>:
+      If you plan to use icons, also install <code>Castor Icons</code> package:
     </p>
     <Source
       language="bash"
       code={`
-        yarn add @onfido/castor @onfido/castor-icons
+        npm install @onfido/castor-icons
       `}
       format
       dark

--- a/docs/_react/intro.story.tsx
+++ b/docs/_react/intro.story.tsx
@@ -11,23 +11,24 @@ export const Intro = () => (
 
     <h2>Install</h2>
     <p>
-      You can install with <code>npm</code>:
+      You can install with <code>npm</code> CLI tool:
     </p>
     <Source
       language="bash"
       code={`
-        npm install @onfido/castor @onfido/castor-icons @onfido/castor-react
+        npm install @onfido/castor @onfido/castor-react
       `}
       format
       dark
     />
+
     <p>
-      Or add with <code>Yarn</code>:
+      If you plan to use icons, also install <code>Castor Icons</code> package:
     </p>
     <Source
       language="bash"
       code={`
-        yarn add @onfido/castor @onfido/castor-icons @onfido/castor-react
+        npm install @onfido/castor-icons
       `}
       format
       dark


### PR DESCRIPTION
## Purpose

Storybook installation instructions are not clear enough on optional usage of  `@onfido/castor-icons`.

## Approach

Instruct on how to additionally install `@onfido/castor-icons`.

Also, leave only instructions using npm, as Yarn is something that is individual per app and setup should be obvious based on their API.

## Testing

On Storybook.

## Risks

N/A
