### PR TITLE
chore: dependabot ignore sass-loader 11 upgrades

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,5 +9,8 @@ update_configs:
       - 'javascript'
     ignored_updates:
       - match:
+          dependency_name: 'sass-loader'
+          version_requirement: '11.x'
+      - match:
           dependency_name: 'webpack'
           version_requirement: '5.x'


### PR DESCRIPTION
## Purpose

Upgrading [to sass-loader 11](https://github.com/onfido/castor/pull/276) fails to build.

This is because it [no longer supports webpack 4](https://github.com/webpack-contrib/sass-loader/releases/tag/v11.0.0), that we need to use for our examples.

## Approach

Adding this version to ignore list for Dependabot.

## Testing

This needs to be merged in order for Dependabot to take new config into consideration.

Upgrade PR should close automatically too.

## Risks

N/A
