### PR TITLE
fix: peer dependency versions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,6 @@
     "!src/**/*.d.ts"
   ],
   "peerDependencies": {
-    "@onfido/castor-icons": "^1.0.0"
+    "@onfido/castor-icons": ">=1.0.0"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -26,8 +26,8 @@
     "!src/**/*.d.ts"
   ],
   "peerDependencies": {
-    "@onfido/castor": "1.0.0",
-    "@onfido/castor-icons": "^1.0.0",
-    "react": "^16.8.0"
+    "@onfido/castor": "^1.0.0",
+    "@onfido/castor-icons": ">=1.0.0",
+    "react": ">=16.8.0"
   }
 }

--- a/scripts/bump-core-peer-dependency.cjs
+++ b/scripts/bump-core-peer-dependency.cjs
@@ -13,6 +13,6 @@ module.exports.writeVersion = function (contents, version) {
   const json = JSON.parse(contents);
   const indent = detectIndent(contents).indent;
   const newline = detectNewline(contents);
-  json.peerDependencies['@onfido/castor'] = version;
+  json.peerDependencies['@onfido/castor'] = `^${version}`;
   return stringifyPackage(json, indent, newline);
 };


### PR DESCRIPTION
## Purpose

Fix to allow newer versions too, like React 17 or castor-icons 2.

## Approach

Change the versions.

## Testing

npm should not complain about installing Castor with React 17 after merging.

## Risks

None.
