### PR TITLE
ci: rename release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches-ignore:
-      - 'release/*.x.x' # already building package when publishing
+      - release/* # already building package when publishing
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - 'main'
+      - main
 
 jobs:
   deploy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,7 +3,7 @@ name: Preview
 on:
   pull_request:
     branches-ignore:
-      - 'release/*.x.x'
+      - release/*
 
 jobs:
   preview:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   push:
     branches:
-      - 'release/*.x.x'
+      - release/*
 
 jobs:
   publish:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ The last line of the script's log will give you the command you need to execute 
 
 ### Release the latest version (example)
 
-You will need `release/*.x.x` branch push permissions.
+You will need `release/*` branch push permissions.
 
 In the following example we assume that:
 
@@ -108,13 +108,13 @@ git checkout main
 git pull
 
 # create and checkout release branch
-git checkout -b release/1.x.x
+git checkout -b release/1.1.0
 
 # use automated release script
 npm run release
 
 # push to trigger 'publish' GitHub Action
-git push --follow-tags origin release/1.x.x
+git push --follow-tags origin release/1.1.0
 ```
 
 Open a release PR to merge the version bump and the changelog back to `main` branch.
@@ -130,7 +130,7 @@ git push origin v1.1.0 -f
 
 ### Release a non-latest minor/patch version (example)
 
-You will need `release/*.x.x` branch push permissions.
+You will need `release/*` branch push permissions.
 
 In the following example we assume that:
 
@@ -149,7 +149,7 @@ git fetch --all --prune
 git checkout v1.2.0
 
 # create and checkout release branch
-git checkout -b release/1.x.x
+git checkout -b release/1.2.x
 
 # cherry-pick required fixes from 'main'
 git cherry-pick 64b6be1
@@ -159,7 +159,7 @@ git cherry-pick 64b6be1
 npm run release
 
 # push to trigger 'publish' GitHub Action
-git push --follow-tags -u origin release/1.x.x
+git push --follow-tags -u origin release/1.2.x
 ```
 
 No need to open a PR to merge a non-latest release back to `main`, nor do tags need to be moved.


### PR DESCRIPTION
## Purpose

Allow branches like `release/1.0.1` to be able to publish too.

## Approach

Rename `release/*.x.x` to `release/*` in all CI related files.

## Testing

Check CI after merge when a new `release/*` branch is created.

## Risks

None, already changed GitHub branch settings.
