### PR TITLE
fix(core): make sure field-label follows 8px grid

### DIFF
--- a/packages/core/src/components/field-label/field-label.scss
+++ b/packages/core/src/components/field-label/field-label.scss
@@ -7,13 +7,11 @@
     color: helpers.color('content-main');
     display: flex;
     flex-flow: column wrap;
-    padding-top: helpers.space(0.5);
+    padding: helpers.space(0.5) 0;
 
-    + .ods-input,
-    + .ods-textarea,
     > .ods-input,
     > .ods-textarea {
-      margin-top: helpers.space(0.5);
+      margin: helpers.space(0.5) 0 helpers.space(-0.5);
     }
   }
 }


### PR DESCRIPTION
## Purpose

`FieldLabel` can be used either individually, or within (and next to) `Input` and `Textarea` components. But it always should follow an 8px grid.

## Approach

Add padding for `FieldLabel` top/bottom of 2 x 4px, then use negative margin in case an input or textarea is used as children to remove the bottom padding.

## Testing

On Storybook inspecting whole component composition so it follows 8px grid.

## Risks

It assumes text is followed by input or textarea as last child.
