### PR TITLE
docs: show how to make optional and required field-label

### DIFF
--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -1,3 +1,4 @@
+import { color } from '@onfido/castor';
 import {
   FieldLabel,
   FieldLabelProps,
@@ -22,6 +23,32 @@ export default {
 
 export const Playground: Story<FieldLabelProps> = (props: FieldLabelProps) => (
   <FieldLabel {...props} />
+);
+
+export const AsOptional: Story<FieldLabelProps> = ({
+  children,
+  ...restProps
+}: FieldLabelProps) => (
+  <FieldLabel {...restProps}>
+    <span>
+      {children}
+      &nbsp;
+      <span style={{ color: color('content-secondary') }}>(optional)</span>
+    </span>
+  </FieldLabel>
+);
+
+export const AsRequired: Story<FieldLabelProps> = ({
+  children,
+  ...restProps
+}: FieldLabelProps) => (
+  <FieldLabel {...restProps}>
+    <span>
+      {children}
+      &nbsp;
+      <span style={{ color: color('content-negative') }}>*</span>
+    </span>
+  </FieldLabel>
 );
 
 interface FieldLabelWithHelperTextProps extends FieldLabelProps {

--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -32,8 +32,7 @@ export const AsOptional: Story<FieldLabelProps> = ({
   <FieldLabel {...restProps}>
     <span>
       {children}
-      &nbsp;
-      <span style={{ color: color('content-secondary') }}>(optional)</span>
+      <span style={{ color: color('content-secondary') }}> (optional)</span>
     </span>
   </FieldLabel>
 );
@@ -45,8 +44,7 @@ export const AsRequired: Story<FieldLabelProps> = ({
   <FieldLabel {...restProps}>
     <span>
       {children}
-      &nbsp;
-      <span style={{ color: color('content-negative') }}>*</span>
+      <span style={{ color: color('content-secondary') }}> *</span>
     </span>
   </FieldLabel>
 );


### PR DESCRIPTION
## Purpose

`FieldLabel` does not provide out-of-box solution for required and optional identification, such should be composed manually.

## Approach

Two new stories shows how "optional" and "required" field labels can be composed.

## Testing

On Storybook.

## Risks

N/A
