### PR TITLE
docs(react): identify that helper-text also used for field-label

### DIFF
--- a/packages/react/src/components/helper-text/helper-text.tsx
+++ b/packages/react/src/components/helper-text/helper-text.tsx
@@ -2,7 +2,7 @@ import { c, classy, HelperTextProps as BaseProps, m } from '@onfido/castor';
 import React from 'react';
 
 /**
- * Intended to be used within `Checkbox` and `Radio` components.
+ * Intended to be used with field components, incl. `FieldLabel` itself.
  */
 export const HelperText = ({
   disabled,


### PR DESCRIPTION
## Purpose

`HelperText` can be used within `Checkbox`, `Radio`, `FieldLabel` components.

## Approach

Identify where `HelperText` can be used.

## Testing

N/A

## Risks

N/A
