### PR TITLE
docs(react): inform that form element children acts as labels

### DIFF
--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -7,7 +7,10 @@ export default {
   component: Checkbox,
   argTypes: {
     ...omit<CheckboxProps>('className', 'style'),
-    children: { control: 'text' },
+    children: {
+      description: 'Acts as a label for an `<input>`.',
+      control: 'text',
+    },
     bordered: {
       table: { type: { summary: 'boolean' } },
     },
@@ -19,6 +22,7 @@ export default {
     },
   },
   args: {
+    children: '',
     bordered: false,
     invalid: false,
     disabled: false,

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -7,7 +7,10 @@ export default {
   component: Input,
   argTypes: {
     ...omit<InputProps>('className', 'style'),
-    children: { control: 'text' },
+    children: {
+      description: 'Acts as a label for an `<input>`.',
+      control: 'text',
+    },
     placeholder: { control: 'text' },
     invalid: {
       table: { type: { summary: 'boolean' } },

--- a/packages/react/src/components/radio/radio.stories.tsx
+++ b/packages/react/src/components/radio/radio.stories.tsx
@@ -7,7 +7,10 @@ export default {
   component: Radio,
   argTypes: {
     ...omit<RadioProps>('className', 'style'),
-    children: { control: 'text' },
+    children: {
+      description: 'Acts as a label for an `<input>`.',
+      control: 'text',
+    },
     bordered: {
       table: { type: { summary: 'boolean' } },
     },
@@ -19,6 +22,7 @@ export default {
     },
   },
   args: {
+    children: '',
     bordered: false,
     invalid: false,
     disabled: false,

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -15,7 +15,10 @@ export default {
   component: Textarea,
   argTypes: {
     ...omit<TextareaProps>('className', 'style'),
-    children: { control: 'text' },
+    children: {
+      description: 'Acts as a label for a `<textarea>`.',
+      control: 'text',
+    },
     placeholder: { control: 'text' },
     resize: {
       table: {


### PR DESCRIPTION
## Purpose

Form elements render labels when such are set via the `children` prop.

## Approach

Inform about behaviour in Storybook stories of React.

## Testing

On Storybook.

## Risks

N/A
