### PR TITLE
docs(react): show label by default on input and textarea

### DIFF
--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -17,6 +17,7 @@ export default {
     },
   },
   args: {
+    children: 'Label',
     placeholder: 'Placeholder',
     invalid: false,
     disabled: false,

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -44,6 +44,7 @@ export default {
     },
   },
   args: {
+    children: 'Label',
     placeholder: 'Placeholder',
     resize: 'vertical',
     rows: 3,


### PR DESCRIPTION
## Purpose

`Input` and `Textarea` React components render labels using `children` prop, such bettern shown by default on stories.

## Approach

Add labels by default on main stories of `Input` and `Textarea` components.

## Testing

On Storybook.

## Risks

N/A
