### PR TITLE
fix(core): compile field-label only once

### DIFF
--- a/packages/core/src/components/index.scss
+++ b/packages/core/src/components/index.scss
@@ -1,3 +1,5 @@
+@use './includes';
+
 @use './button/button';
 @forward './button/button';
 @use './checkbox/checkbox';
@@ -18,10 +20,6 @@
 @forward './textarea/textarea';
 
 @mixin components() {
-  // conditionally includable in other components
-  @include field-label.FieldLabel();
-
-  // all the rest
   @include button.Button();
   @include checkbox.Checkbox();
   @include helper-text.HelperText();
@@ -30,4 +28,8 @@
   @include radio.Radio();
   @include search.Search();
   @include textarea.Textarea();
+
+  @if not includes.the('field-label') {
+    @include field-label.FieldLabel();
+  }
 }


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/293 main compilation of all components is wrong, as conditional inclusion uses `includes` for keeping a map of what has been included.

## Approach

Rollback to checking for whether "field-label" was already included.

Another option is to exclude this component from a list of all components completely, however then we might introduce a bug when "field-label" is removed from both "input" and "textarea".

## Testing

Tested local build.

## Risks

N/A
