### PR TITLE
fix(core): correct placement of "bordered" indicator-container

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -14,6 +14,7 @@
     gap: $padding;
     grid-auto-flow: column;
     padding: $padding;
+    place-content: start;
     position: relative;
 
     &.-bordered {


### PR DESCRIPTION
## Purpose

Placement of "bordered" indicator-container content is wrong.

## Approach

Setting placement of content to be "start" position.

## Testing

On Storybook checking `Checkbox` and `Radio` components with labels and "bordered".

## Risks

N/A
