### PR TITLE
docs: correct color of "required" field-label indication

### DIFF
--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -44,7 +44,7 @@ export const AsRequired: Story<FieldLabelProps> = ({
   <FieldLabel {...restProps}>
     <span>
       {children}
-      <span style={{ color: color('content-secondary') }}> *</span>
+      <span style={{ color: color('content-negative') }}> *</span>
     </span>
   </FieldLabel>
 );


### PR DESCRIPTION
## Purpose

Following [suggestion with a bug](https://github.com/onfido/castor/pull/292#discussion_r573784310) wrong color applied to indication of "required" field-label.

## Approach

Change color to correct "negative" one.

## Testing

On Storybook.

## Risks

N/A
