### PR TITLE
docs: make better "required" field-label example

### DIFF
--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -31,8 +31,8 @@ export const AsOptional: Story<FieldLabelProps> = ({
 }: FieldLabelProps) => (
   <FieldLabel {...restProps}>
     <span>
-      {children}
-      <span style={{ color: color('content-secondary') }}> (optional)</span>
+      {children}{' '}
+      <abbr style={{ color: color('content-secondary') }}>(optional)</abbr>
     </span>
   </FieldLabel>
 );
@@ -43,8 +43,10 @@ export const AsRequired: Story<FieldLabelProps> = ({
 }: FieldLabelProps) => (
   <FieldLabel {...restProps}>
     <span>
-      {children}
-      <span style={{ color: color('content-negative') }}> *</span>
+      {children}{' '}
+      <abbr aria-label="required" style={{ color: color('content-negative') }}>
+        *
+      </abbr>
     </span>
   </FieldLabel>
 );

--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -32,7 +32,7 @@ export const AsOptional: Story<FieldLabelProps> = ({
   <FieldLabel {...restProps}>
     <span>
       {children}{' '}
-      <abbr style={{ color: color('content-secondary') }}>(optional)</abbr>
+      <span style={{ color: color('content-secondary') }}>(optional)</span>
     </span>
   </FieldLabel>
 );


### PR DESCRIPTION
## Purpose

Improve "required" `FieldLabel` component example on Storybook, following the [existing implementation(https://github.com/onfido/castor/pull/292).

## Approach

- use `<abbr>` tag
- set `aria-label` for a "required" field

## Testing

On Storybook.

## Risks

N/A
