### PR TITLE
docs: inform about using with typescript

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -181,4 +181,4 @@ Or using the Sass helper:
 
 Components have basic types exported so that you could create your own JS/TS variations using any renderer chosen (for example, Vue or Angular).
 
-Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for types to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, however otherwise it must be installed manually even if you don't plan to use icons.
+Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for **types** to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, otherwise it must be installed manually even if you don't plan to use icons.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -178,3 +178,7 @@ Or using the Sass helper:
 ```html
 <button class="ods-button -action--primary round">Round Button</button>
 ```
+
+Components have basic types exported so that you could create your own JS/TS variations using any renderer chosen (for example, Vue or Angular).
+
+Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for types to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, however otherwise it must be installed manually even if you don't plan to use icons.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -58,6 +58,14 @@ You may wish to configure your bundler to transpile to a different module syntax
 
 For example, you might choose UMD module syntax targeting ES5 if your app needs to support IE11 (please note that Castor is not tested in Internet Explorer).
 
+### Use with TypeScript
+
+Components extend base prop types with JSX additions.
+
+When using with TypeScript, always import types from `@onfido/castor-react`.
+
+Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for types to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, however otherwise it must be installed manually even if you don't plan to use icons.
+
 ### Make custom styled components
 
 You should use props for each component modifier, but it is also possible to create custom styled components.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -64,7 +64,7 @@ Components extend base prop types with JSX additions.
 
 When using with TypeScript, always import types from `@onfido/castor-react`.
 
-Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for types to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, however otherwise it must be installed manually even if you don't plan to use icons.
+Please note that the `@onfido/castor-icons` package is a peer dependency and is required to be installed for **types** to work properly. Yarn and newer versions of npm (using lockfile v2) will resolve it, otherwise it must be installed manually even if you don't plan to use icons.
 
 ### Make custom styled components
 


### PR DESCRIPTION
## Purpose

Having `@onfido/castor-icons` as peer dependency for types might be problematic when using TypeScript + npm v6 without icons.

## Approach

Inform about situation, and provide recommendation on how to resolve the problem.

## Testing

N/A

## Risks

N/A
