### PR TITLE
fix(core): correctly space full width checkbox and radio

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -12,7 +12,7 @@
     color: helpers.color('content-main');
     display: inline-grid;
     gap: $padding;
-    grid-auto-flow: column;
+    grid: auto-flow / auto 1fr;
     padding: $padding;
     place-content: start;
     position: relative;


### PR DESCRIPTION
## Purpose

Fixes Checkbox inside containers that force its width to be larger than its content.

![image](https://user-images.githubusercontent.com/18623773/108214130-b76d7800-7127-11eb-8ba0-ffc21a1da976.png)

## Approach

Make the checkbox indicator use only its own width (`auto`) and the label use the rest of available space (`1fr`).

## Testing

Can't reproduce on Storybook 🤔 
But essentially a `display: grid` parent and a Checkbox inside.

## Risks

None.
