### PR TITLE
feat(core): add .-touched:invalid as an alternative to .-invalid

### DIFF
--- a/packages/core/src/components/checkbox/checkbox.scss
+++ b/packages/core/src/components/checkbox/checkbox.scss
@@ -56,7 +56,8 @@
   }
 
   // indicating invalid and not [disabled] input
-  .ods-checkbox.-invalid:not(:disabled) {
+  .ods-checkbox.-invalid:not(:disabled),
+  .ods-checkbox.-touched:invalid:not(:disabled) {
     // and [checked] indicator
     &:checked + .ods-input-indicator::after {
       border-color: helpers.color('content-always-light');

--- a/packages/core/src/components/radio/radio.scss
+++ b/packages/core/src/components/radio/radio.scss
@@ -30,8 +30,11 @@
   }
 
   // indicating invalid input
-  .ods-radio.-invalid + .ods-input-indicator::after {
-    background-color: helpers.color('content-negative');
+  .ods-radio.-invalid,
+  .ods-radio.-touched:invalid {
+    + .ods-input-indicator::after {
+      background-color: helpers.color('content-negative');
+    }
   }
 
   // indicating [disabled] input

--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -83,8 +83,8 @@
     > .ods-checkbox:checked,
     > .ods-checkbox:indeterminate,
     > .ods-radio:checked {
-      &:not(.-touched:invalid:disabled) + .ods-input-indicator,
-      &:not(.-invalid:disabled) + .ods-input-indicator {
+      &:not(.-invalid:disabled) + .ods-input-indicator,
+      &:not(.-touched:invalid:disabled) + .ods-input-indicator {
         background-color: helpers.color('background-action-subtle');
         border-color: helpers.color('border-action-subtle');
       }

--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -33,7 +33,8 @@
     margin: $input-margin;
     opacity: 0;
 
-    &.-invalid {
+    &.-invalid,
+    &.-touched:invalid {
       @include mixins.with-outer-focus(
         'negative',
         '+ .ods-input-indicator::before'
@@ -82,7 +83,8 @@
     > .ods-checkbox:checked,
     > .ods-checkbox:indeterminate,
     > .ods-radio:checked {
-      &:not(:disabled):not(.-invalid) + .ods-input-indicator {
+      &:not(.-touched:invalid:disabled) + .ods-input-indicator,
+      &:not(.-invalid:disabled) + .ods-input-indicator {
         background-color: helpers.color('background-action-subtle');
         border-color: helpers.color('border-action-subtle');
       }
@@ -116,7 +118,9 @@
 
   // indicating invalid input
   .ods-checkbox.-invalid,
-  .ods-radio.-invalid {
+  .ods-checkbox.-touched:invalid,
+  .ods-radio.-invalid,
+  .ods-radio.-touched:invalid {
     + .ods-input-indicator::before {
       border-color: helpers.color('border-negative');
     }

--- a/packages/core/src/mixins/as-text-input.scss
+++ b/packages/core/src/mixins/as-text-input.scss
@@ -26,7 +26,8 @@
   // stylelint-disable-next-line order/order
   @include mixins.with-inner-focus('action', $border-width);
 
-  &.-invalid {
+  &.-invalid,
+  &.-touched:invalid {
     @include mixins.with-inner-focus('negative', $border-width);
 
     border-color: helpers.color('border-negative');


### PR DESCRIPTION
## Purpose

Enable upcoming `<Form>` and `<Field>` components, as well as customer specific implementations, to simply mark a field/input as `.-touched` to take full advantage of HTML5 validation.

Adding `.-touched` on blur is much simpler than replicating the entire validation logic in JavaScript.
This is even more valuable for non-React (or vanilla) customers that want minimal JS.

For example:

https://user-images.githubusercontent.com/18623773/108243003-7edc9700-7145-11eb-8cde-82f3d9976240.mov

## Approach

Add `.-touched:invalid` to every occurrence of `.-invalid`.

## Testing

Video above.

## Risks

More power means more responsibility.
