### PR TITLE
feat: add fieldset-legend component

### DIFF
--- a/packages/core/src/components/fieldset-legend/fieldset-legend.scss
+++ b/packages/core/src/components/fieldset-legend/fieldset-legend.scss
@@ -1,0 +1,12 @@
+@use '../../helpers';
+
+@mixin FieldsetLegend() {
+  .ods-fieldset-legend {
+    @include helpers.font('300-regular');
+
+    color: helpers.color('content-main');
+    display: flex;
+    flex-flow: column wrap;
+    padding: helpers.space(0.5) 0;
+  }
+}

--- a/packages/core/src/components/index.scss
+++ b/packages/core/src/components/index.scss
@@ -10,6 +10,8 @@
 @forward './field-label/field-label';
 @use './field/field';
 @forward './field/field';
+@use './fieldset-legend/fieldset-legend';
+@forward './fieldset-legend/fieldset-legend';
 @use './fieldset/fieldset';
 @forward './fieldset/fieldset';
 @use './helper-text/helper-text';
@@ -32,6 +34,7 @@
   @include button.Button();
   @include checkbox.Checkbox();
   @include field.Field();
+  @include fieldset-legend.FieldsetLegend();
   @include fieldset.Fieldset();
   @include helper-text.HelperText();
   @include icon.Icon();

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -73,16 +73,15 @@ interface CheckboxesWithFieldsetLegendProps extends CheckboxProps {
 }
 
 export const WithFieldsetLegend = ({
-  name,
   legend,
   ...restCheckboxProps
 }: CheckboxesWithFieldsetLegendProps) => (
   <Fieldset>
     <FieldsetLegend>{legend}</FieldsetLegend>
-    <Checkbox {...restCheckboxProps} name={name} value="1">
+    <Checkbox {...restCheckboxProps} value="1">
       one
     </Checkbox>
-    <Checkbox {...restCheckboxProps} name={name} value="2">
+    <Checkbox {...restCheckboxProps} value="2">
       two
     </Checkbox>
   </Fieldset>

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -2,6 +2,7 @@ import {
   Checkbox,
   CheckboxProps,
   Fieldset,
+  FieldsetLegend,
   HelperText,
   Validation,
 } from '@onfido/castor-react';
@@ -66,6 +67,34 @@ export const AsIndeterminate = (props: CheckboxProps) => {
   return <Checkbox {...props} ref={checkboxRef} onChange={handleChange} />;
 };
 
+interface CheckboxesWithFieldsetLegendProps extends CheckboxProps {
+  name: string;
+  legend: string;
+}
+
+export const WithFieldsetLegend = ({
+  name,
+  legend,
+  ...restCheckboxProps
+}: CheckboxesWithFieldsetLegendProps) => (
+  <Fieldset>
+    <FieldsetLegend>{legend}</FieldsetLegend>
+    <Checkbox {...restCheckboxProps} name={name} value="1">
+      one
+    </Checkbox>
+    <Checkbox {...restCheckboxProps} name={name} value="2">
+      two
+    </Checkbox>
+  </Fieldset>
+);
+WithFieldsetLegend.argTypes = omit<CheckboxesWithFieldsetLegendProps>(
+  'children'
+);
+WithFieldsetLegend.args = {
+  name: 'checkboxes-with-fieldset-legend',
+  legend: 'Legend',
+};
+
 interface CheckboxWithHelperTextProps extends CheckboxProps {
   label: string;
   helperText: string;
@@ -99,14 +128,14 @@ export const WithValidation = ({
   withIcon,
   ...restCheckboxProps
 }: CheckboxWithValidationProps) => (
-  <Fieldset>
+  <>
     <Checkbox {...restCheckboxProps} invalid={Boolean(validation)}>
       {label}
     </Checkbox>
     <Validation state="error" withIcon={withIcon}>
       {validation}
     </Validation>
-  </Fieldset>
+  </>
 );
 WithValidation.argTypes = omit<CheckboxWithHelperTextProps>(
   'children',

--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -89,6 +89,7 @@ export const WithInput = ({
     <Input id={id} />
   </Field>
 );
+WithInput.argTypes = omit<FieldLabelWithInputProps>('children');
 WithInput.args = {
   id: 'field-label-with-input',
   label: 'Label',
@@ -111,6 +112,7 @@ export const WithTextarea = ({
     <Textarea id={id} />
   </Field>
 );
+WithTextarea.argTypes = omit<FieldLabelWithTextareaProps>('children');
 WithTextarea.args = {
   id: 'field-label-with-textarea',
   label: 'Label',

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
@@ -78,7 +78,7 @@ export const WithHelperText = ({
 );
 WithHelperText.argTypes = omit<FieldsetLegendWithHelperTextProps>('children');
 WithHelperText.args = {
-  legend: 'Lgend',
+  legend: 'Legend',
   helperText: 'Helper text',
 };
 

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
@@ -1,0 +1,135 @@
+import { color } from '@onfido/castor';
+import {
+  Asterisk,
+  Checkbox,
+  Fieldset,
+  FieldsetLegend,
+  FieldsetLegendProps,
+  HelperText,
+  Radio,
+} from '@onfido/castor-react';
+import React from 'react';
+import { Meta, omit, Story } from '../../../../../docs';
+
+export default {
+  title: 'React/FieldsetLegend',
+  component: FieldsetLegend,
+  argTypes: {
+    ...omit<FieldsetLegendProps>('className', 'style'),
+    children: { control: 'text' },
+  },
+  args: {
+    children: 'Legend',
+  },
+} as Meta<FieldsetLegendProps>;
+
+export const Playground: Story<FieldsetLegendProps> = (
+  props: FieldsetLegendProps
+) => (
+  <Fieldset>
+    <FieldsetLegend {...props} />
+  </Fieldset>
+);
+
+export const AsOptional: Story<FieldsetLegendProps> = ({
+  children,
+  ...restProps
+}: FieldsetLegendProps) => (
+  <Fieldset>
+    <FieldsetLegend {...restProps}>
+      <span>
+        {children}{' '}
+        <span style={{ color: color('content-secondary') }}>(optional)</span>
+      </span>
+    </FieldsetLegend>
+  </Fieldset>
+);
+
+export const AsRequired: Story<FieldsetLegendProps> = ({
+  children,
+  ...restProps
+}: FieldsetLegendProps) => (
+  <Fieldset>
+    <FieldsetLegend {...restProps}>
+      <span>
+        {children}
+        <Asterisk aria-label="required" />
+      </span>
+    </FieldsetLegend>
+  </Fieldset>
+);
+
+interface FieldsetLegendWithHelperTextProps extends FieldsetLegendProps {
+  legend: string;
+  helperText: string;
+}
+
+export const WithHelperText = ({
+  legend,
+  helperText,
+  ...restFieldsetLegendProps
+}: FieldsetLegendWithHelperTextProps) => (
+  <Fieldset>
+    <FieldsetLegend {...restFieldsetLegendProps}>
+      {legend}
+      <HelperText>{helperText}</HelperText>
+    </FieldsetLegend>
+  </Fieldset>
+);
+WithHelperText.argTypes = omit<FieldsetLegendWithHelperTextProps>('children');
+WithHelperText.args = {
+  legend: 'Lgend',
+  helperText: 'Helper text',
+};
+
+interface FieldsetLegendWithCheckboxesProps extends FieldsetLegendProps {
+  name: string;
+  legend: string;
+}
+
+export const WithCheckboxes = ({
+  name,
+  legend,
+  ...restFieldsetLegendProps
+}: FieldsetLegendWithCheckboxesProps) => (
+  <Fieldset>
+    <FieldsetLegend {...restFieldsetLegendProps}>{legend}</FieldsetLegend>
+    <Checkbox name={name} value="1">
+      one
+    </Checkbox>
+    <Checkbox name={name} value="2">
+      two
+    </Checkbox>
+  </Fieldset>
+);
+WithCheckboxes.argTypes = omit<FieldsetLegendWithCheckboxesProps>('children');
+WithCheckboxes.args = {
+  name: 'fieldset-legend-with-checkboxes',
+  legend: 'Legend',
+};
+
+interface FieldsetLegendWithRadiosProps extends FieldsetLegendProps {
+  name: string;
+  legend: string;
+}
+
+export const WithRadios = ({
+  name,
+  legend,
+  ...restFieldsetLegendProps
+}: FieldsetLegendWithRadiosProps) => (
+  <Fieldset>
+    <FieldsetLegend {...restFieldsetLegendProps}>{legend}</FieldsetLegend>
+    <Radio name={name} value="yes">
+      yes
+    </Radio>
+    <Radio name={name} value="no">
+      no
+    </Radio>
+  </Fieldset>
+);
+WithRadios.argTypes = omit<FieldsetLegendWithRadiosProps>('children');
+WithRadios.args = {
+  name: 'fieldset-legend-with-radios',
+  legend: 'Legend',
+};

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
@@ -1,0 +1,14 @@
+import { c, classy } from '@onfido/castor';
+import React from 'react';
+
+/**
+ * Intended to be used within `Fieldset` component, providing a text legend.
+ */
+export const FieldsetLegend = ({
+  className,
+  ...restProps
+}: FieldsetLegendProps): JSX.Element => (
+  <legend {...restProps} className={classy(c('fieldset-legend'), className)} />
+);
+
+export type FieldsetLegendProps = JSX.IntrinsicElements['legend'];

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
@@ -2,7 +2,7 @@ import { c, classy } from '@onfido/castor';
 import React from 'react';
 
 /**
- * Intended to be used within `Fieldset` component, providing a text legend.
+ * Use within `Fieldset` component to provide a text legend.
  */
 export const FieldsetLegend = ({
   className,

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './button/button';
 export * from './checkbox/checkbox';
 export * from './field-label/field-label';
 export * from './field/field';
+export * from './fieldset-legend/fieldset-legend';
 export * from './fieldset/fieldset';
 export * from './helper-text/helper-text';
 export * from './icon/icon';

--- a/packages/react/src/components/radio/radio.stories.tsx
+++ b/packages/react/src/components/radio/radio.stories.tsx
@@ -1,5 +1,6 @@
 import {
   Fieldset,
+  FieldsetLegend,
   HelperText,
   Radio,
   RadioProps,
@@ -57,6 +58,32 @@ export const Disabled = storyOf(Radio, 'disabled', [true, false], {
 Disabled.argTypes = omit<RadioProps>('disabled');
 Disabled.args = { name: 'disabled-playground' };
 
+interface RadiosWithFieldsetLegendProps extends RadioProps {
+  name: string;
+  legend: string;
+}
+
+export const WithFieldsetLegend = ({
+  name,
+  legend,
+  ...restRadioProps
+}: RadiosWithFieldsetLegendProps) => (
+  <Fieldset>
+    <FieldsetLegend>{legend}</FieldsetLegend>
+    <Radio {...restRadioProps} name={name} value="yes">
+      yes
+    </Radio>
+    <Radio {...restRadioProps} name={name} value="no">
+      no
+    </Radio>
+  </Fieldset>
+);
+WithFieldsetLegend.argTypes = omit<RadiosWithFieldsetLegendProps>('children');
+WithFieldsetLegend.args = {
+  name: 'radios-with-fieldset-legend',
+  legend: 'Legend',
+};
+
 interface RadioWithHelperTextProps extends RadioProps {
   label: string;
   helperText: string;
@@ -90,14 +117,14 @@ export const WithValidation = ({
   withIcon,
   ...restRadioProps
 }: RadioWithValidationProps) => (
-  <Fieldset>
+  <>
     <Radio {...restRadioProps} invalid={Boolean(validation)}>
       {label}
     </Radio>
     <Validation state="error" withIcon={withIcon}>
       {validation}
     </Validation>
-  </Fieldset>
+  </>
 );
 WithValidation.argTypes = omit<RadioWithHelperTextProps>(
   'children',

--- a/packages/react/src/components/radio/radio.stories.tsx
+++ b/packages/react/src/components/radio/radio.stories.tsx
@@ -64,16 +64,15 @@ interface RadiosWithFieldsetLegendProps extends RadioProps {
 }
 
 export const WithFieldsetLegend = ({
-  name,
   legend,
   ...restRadioProps
 }: RadiosWithFieldsetLegendProps) => (
   <Fieldset>
     <FieldsetLegend>{legend}</FieldsetLegend>
-    <Radio {...restRadioProps} name={name} value="yes">
+    <Radio {...restRadioProps} value="yes">
       yes
     </Radio>
-    <Radio {...restRadioProps} name={name} value="no">
+    <Radio {...restRadioProps} value="no">
       no
     </Radio>
   </Fieldset>


### PR DESCRIPTION
## Purpose

Add FieldsetLegend component, that is used same as `<legend>` element within `<fieldset>`.

## Approach

Implements FieldsetLegend component.

## Testing

On Storybook preview, including Checkbox and Radio stories "with fieldset legend".

## Risks

N/A
