### PR TITLE
chore: dependabot ignore autoprefixer 10 upgrades

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,6 +9,9 @@ update_configs:
       - 'javascript'
     ignored_updates:
       - match:
+          dependency_name: 'autoprefixer'
+          version_requirement: '10.x'
+      - match:
           dependency_name: 'sass-loader'
           version_requirement: '11.x'
       - match:


### PR DESCRIPTION
## Purpose

Upgrading [to autoprefixer 10](https://github.com/onfido/castor/pull/352) fails to build.

This is because it [is based on PostCSS 8](https://github.com/postcss/autoprefixer/releases/tag/10.0.0), and is [not supported by Parcel 1](https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users#parcel) we currently use (with no intentions to upgrade for now).

## Approach

Adding this version to ignore list for Dependabot.

## Testing

This needs to be merged in order for Dependabot to take new config into consideration.

Upgrade PR should close automatically too.

## Risks

N/A
