### PR TITLE
chore: dependabot ignore postcss-modules 4 upgrades

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,6 +12,9 @@ update_configs:
           dependency_name: 'autoprefixer'
           version_requirement: '10.x'
       - match:
+          dependency_name: 'postcss-modules'
+          version_requirement: '4.x'
+      - match:
           dependency_name: 'sass-loader'
           version_requirement: '11.x'
       - match:


### PR DESCRIPTION
## Purpose

Upgrading [to postcss-modules 4](https://github.com/onfido/castor/pull/347) fails to build.

This is because it [is based on PostCSS 8](https://github.com/css-modules/postcss-modules/blob/master/CHANGELOG.md#400), and is [not supported by Parcel 1](https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users#parcel) we currently use (with no intentions to upgrade for now).

## Approach

Adding this version to ignore list for Dependabot.

## Testing

This needs to be merged in order for Dependabot to take new config into consideration.

Upgrade PR should close automatically too.

## Risks

N/A
