### PR TITLE
docs: include theme color tokens for storybook

### DIFF
--- a/docs/colors/colors.ts
+++ b/docs/colors/colors.ts
@@ -1,0 +1,7 @@
+import { Color } from '@onfido/castor';
+import tokens from './tokens.scss';
+
+export const colors = Object.keys(tokens).reduce((accumulator, name) => {
+  const [, color] = name.match(/^--ods-color-([a-z0-9-]+)$/) ?? [];
+  return color ? [...accumulator, color] : accumulator;
+}, []) as Color[];

--- a/docs/colors/index.ts
+++ b/docs/colors/index.ts
@@ -1,0 +1,1 @@
+export { colors } from './colors';

--- a/docs/colors/tokens.scss
+++ b/docs/colors/tokens.scss
@@ -1,0 +1,6 @@
+@use '~@onfido/castor';
+
+:export {
+  @include castor.day();
+  @include castor.night();
+}

--- a/docs/index.ts
+++ b/docs/index.ts
@@ -1,6 +1,3 @@
-import tokens from './tokens.scss';
-
 export * from './docs';
 export * from './Story';
 export * from './storyOf';
-export { tokens };

--- a/docs/tokens.scss
+++ b/docs/tokens.scss
@@ -1,5 +1,0 @@
-@use '~@onfido/castor';
-
-:export {
-  @include castor.tokens();
-}

--- a/packages/react/src/components/icon/icon.stories.tsx
+++ b/packages/react/src/components/icon/icon.stories.tsx
@@ -1,13 +1,8 @@
-import { Color } from '@onfido/castor';
 import { iconNames } from '@onfido/castor-icons';
 import { Icon, IconProps } from '@onfido/castor-react';
 import React from 'react';
-import { Meta, omit, Story, storyOf, tokens } from '../../../../../docs';
-
-const colors = Object.keys(tokens).reduce((accumulator, name) => {
-  const [, color] = name.match(/^--ods-color-([a-z0-9-]+)$/) ?? [];
-  return color ? [...accumulator, color] : accumulator;
-}, []) as Color[];
+import { Meta, omit, Story, storyOf } from '../../../../../docs';
+import { colors } from '../../../../../docs/colors';
 
 const [firstIconName] = iconNames;
 


### PR DESCRIPTION
## Purpose

Picker for a Castor color (currently used on an `Icon` story only) does not include theme tokens.

This closes #152.

## Approach

Merge themes, then import tokens and generate an array of color (tokens) available.

## Testing

On Storybook, `Icon` story by changing a color.

## Risks

If themes have different colors tokens set, then such would appear on a dropdown but can have no value.

This should not happen, but also something to think about on how a validation of theme tokens could be done to make sure each theme has all but not other tokens defined.
