### PR TITLE
fix: checkbox grid and ghost gap

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -12,7 +12,7 @@
     color: helpers.color('content-main');
     display: inline-grid;
     gap: $padding;
-    grid: auto-flow / auto 1fr;
+    grid: auto / auto-flow;
     padding: $padding;
     place-content: start;
     position: relative;


### PR DESCRIPTION
## Purpose

Fixes an issue where non-label Checkbox/Radio grids apply gap to a ghost column, because it is fixed in CSS.
Introduced in #327.

![Screenshot 2021-02-25 at 13 09 48](https://user-images.githubusercontent.com/18623773/109158099-d218a000-776a-11eb-990d-35b9832a58d5.png)

## Approach

Invert the auto-flow grid axis back to column, but apply `auto` as a value for the rows.

## Testing

Both in Storybook, fixes the described bug, and in Client Manager, desired behaviour described in #327 is kept.

## Risks

None.
