### PR TITLE
fix(core): correct background color of simulated input

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -69,6 +69,7 @@
 
     // "outline" (simulating <input />)
     &::before {
+      background-color: helpers.color('background-input');
       border: 2px solid helpers.color('border-input');
     }
   }


### PR DESCRIPTION
## Purpose

Change current "transparent" background color of simulated input to "background-input".

## Approach

Add background color of "background-input" to simulated input.

## Testing

On Storybook.

## Risks

N/A
