### PR TITLE
docs: suggest to protect release branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,4 +166,4 @@ npm run release
 git push --follow-tags -u origin release/1.2.x
 ```
 
-No need to open a PR to merge a non-latest release back to `main`, nor do tags need to be moved.
+No need to open a PR to merge a non-latest release back to `main`, nor do tags need to be moved. However, consider protecting the branch `release/1.2.x` against deletion under GitHub's "Branches" settings.


### PR DESCRIPTION
## Purpose

When releasing a non-latest minor/patch version, we no longer place back tags to keep track of changelog versioning. For this suggestion is to protect such branches against deletion.

## Approach

Suggest to protect non-latest release branches.

## Testing

On GitHub itself.

## Risks

N/A
