### PR TITLE
feat: set background color for "bordered" indicator container

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -80,6 +80,13 @@
       border-color: helpers.color('border-separator');
     }
 
+    > .ods-checkbox,
+    > .ods-radio {
+      &:not(:disabled) + .ods-input-indicator {
+        background-color: helpers.color('background-input');
+      }
+    }
+
     // and [checked] (or [indeterminate] when applicable) but not disabled and not invalid input
     > .ods-checkbox:checked,
     > .ods-checkbox:indeterminate,
@@ -144,5 +151,6 @@
   // container children
   .ods-input-indicator ~ * {
     margin-right: helpers.space(2) - $padding;
+    position: relative;
   }
 }


### PR DESCRIPTION
## Purpose

Bordered Checkbox and Radio is to have a background color of "background-input".

## Approach

Set background color for IndicatorContainer when Checkbox and/or Radio is not disabled (for disabled it still stays as "transparent").

## Testing

On Storybook.

## Risks

N/A
