### PR TITLE
docs: optimize storybook theming by including base tokens only once

### DIFF
--- a/docs/themer/themes.scss
+++ b/docs/themer/themes.scss
@@ -1,6 +1,10 @@
 @use '~@onfido/castor';
 
+:root {
+  @include castor.tokens();
+}
+
 :global {
-  @include castor.day('class');
-  @include castor.night('class');
+  @include castor.day('class', 'raw');
+  @include castor.night('class', 'raw');
 }


### PR DESCRIPTION
## Purpose

We allow to use "raw" version of a "classes" theme, that excludes base tokens. Base tokens can then be included separately, and only once.

## Approach

For Storybook include base Castor tokens once, then use "day" and "night" themes in "raw" version.

## Testing

On Storybook - theming should work, can inspect where what tokens are placed.

## Risks

N/A
