### PR TITLE
fix(react): exclude "children" from search component props type

### DIFF
--- a/packages/react/src/components/search/search.tsx
+++ b/packages/react/src/components/search/search.tsx
@@ -23,4 +23,4 @@ export const Search = withRef(
 );
 Search.displayName = 'Search';
 
-export type SearchProps = Omit<InputProps, 'invalid' | 'type'>;
+export type SearchProps = Omit<InputProps, 'type' | 'invalid' | 'children'>;


### PR DESCRIPTION
## Purpose

Search component uses Input component under the hood, it also passes all the rest of the props to it.

Providing "children" to Input component renders a field label alongside an input.

This however breaks the Search component if allowed:

![Screenshot 2021-03-03 at 16 35 20](https://user-images.githubusercontent.com/20243687/109840264-df88cb00-7c3f-11eb-98d6-7715e96af649.png)

## Approach

Exclude "children" from Search component props type.

## Testing

Locally, when coding.

## Risks

It does not disallow to still set children, e.g. if TS is not used.

However, designs point out that field labels should not even be used on Search component.
