### PR TITLE
fix(core): correct style of "invalid" input's placeholder

### DIFF
--- a/packages/core/src/mixins/as-text-input.scss
+++ b/packages/core/src/mixins/as-text-input.scss
@@ -32,6 +32,10 @@
 
     border-color: helpers.color('border-negative');
     color: helpers.color('content-negative');
+
+    &::placeholder {
+      color: inherit;
+    }
   }
 
   &:disabled {


### PR DESCRIPTION
## Purpose

"invalid" Input component's placeholder should be styled as "red", as seen in design:

![Screenshot 2021-03-04 at 11 46 31](https://user-images.githubusercontent.com/20243687/109959365-45785f80-7cdf-11eb-9bb8-70e2c18d720f.png)

Same does applie to Textarea too.

## Approach

Set color of a placeholder in "invalid" state to inherit "red" color.

## Testing

On Storybook.

## Risks

N/A
