### PR TITLE
chore: allow to use underscored (starting with "_") unused vars

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,11 @@
   ],
   "settings": { "react": { "version": "detect" } },
   "rules": {
-    "@typescript-eslint/explicit-module-boundary-types": "off"
+    "@typescript-eslint/explicit-module-boundary-types": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "varsIgnorePattern": "^_" }
+    ]
   },
   "overrides": [
     {


### PR DESCRIPTION
## Purpose

Such change would allow to e.g. discard some variables that are not used anywhere but should not travel further, like props that you pass to other components.

## Approach

Use [linting rule](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md) to setup a pattern to ignore, otherwise error.

Originally suggested by @rabelloo.

## Testing

Tested locally in code.

## Risks

N/A
