### PR TITLE
fix(core): set placeholder opacity so each browser is aligned

### DIFF
--- a/packages/core/src/mixins/as-text-input.scss
+++ b/packages/core/src/mixins/as-text-input.scss
@@ -16,6 +16,7 @@
 
   &::placeholder {
     color: helpers.color('content-placeholder');
+    opacity: 1; // Firefox has reduced opacity
   }
 
   &:hover {


### PR DESCRIPTION
## Purpose

Firefox has a reduced opacity set for placeholders.

Opacity should be aligned between each browser.

## Approach

Set opacity so that each browser has aligned one.

## Testing

On Storybook, using a few different browsers including Firefox.

## Risks

N/A
