### PR TITLE
docs: add html input stories

### DIFF
--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -1,0 +1,67 @@
+import { htmlMatrix, Meta, omit, Story } from '../../../../../docs';
+import { Input, InputProps } from './input.story';
+
+const disabled = [true, false] as const;
+const invalid = [true, false] as const;
+
+const type = [
+  'text',
+  'number',
+  'email',
+  'password',
+  'tel',
+  'url',
+  'search',
+] as const;
+type.toString = () => type.map((value) => `"${value}"`).join('|');
+
+export default {
+  title: 'Core/Input',
+  component: Input,
+  argTypes: {
+    disabled: {
+      table: { type: { summary: 'boolean' } },
+    },
+    invalid: {
+      table: { type: { summary: 'boolean' } },
+    },
+    placeholder: {
+      table: { type: { summary: 'string' } },
+    },
+    type: {
+      control: { type: 'radio', options: type },
+      table: {
+        type: { summary: type.toString() },
+        defaultValue: { summary: 'text' },
+      },
+    },
+  },
+  args: {
+    disabled: false,
+    invalid: false,
+    placeholder: 'Placeholder',
+    type: 'text',
+  },
+  parameters: { display: 'flex' },
+} as Meta<InputProps>;
+
+export const Playground: Story<InputProps> = (props) => Input(props);
+
+export const Invalid = htmlMatrix(Input, { invalid });
+Invalid.argTypes = omit<InputProps>('invalid');
+
+export const Disabled = htmlMatrix(Input, { disabled });
+Disabled.argTypes = omit<InputProps>('disabled');
+
+export const AllCombinations = htmlMatrix(
+  Input,
+  { disabled, invalid },
+  (props) => Input({ ...props, value: value(props) })
+);
+AllCombinations.parameters = {
+  display: 'grid',
+  columns: 'repeat(2, 1fr)',
+};
+
+const value = ({ disabled, invalid }: InputProps) =>
+  `${invalid ? 'invalid' : 'valid'} ${disabled ? 'disabled' : ''}`;

--- a/packages/core/src/components/input/input.story.tsx
+++ b/packages/core/src/components/input/input.story.tsx
@@ -1,0 +1,14 @@
+import { InputProps as BaseProps } from '@onfido/castor';
+import { html } from '../../../../../docs';
+import { c, classy, m } from '../../utils';
+
+export interface InputProps extends BaseProps {
+  value?: string;
+}
+
+export const Input = ({ type = 'text', invalid, ...props }: InputProps) =>
+  html('input', {
+    ...props,
+    class: classy(c('input'), m({ invalid })),
+    type,
+  });

--- a/packages/core/src/components/input/input.ts
+++ b/packages/core/src/components/input/input.ts
@@ -1,4 +1,5 @@
 export interface InputProps {
-  type?: 'text' | 'number' | 'email' | 'password' | 'tel' | 'url' | 'search';
+  disabled?: boolean;
   invalid?: boolean;
+  type?: 'text' | 'number' | 'email' | 'password' | 'tel' | 'url' | 'search';
 }

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -6,48 +6,71 @@ import {
   Validation,
 } from '@onfido/castor-react';
 import React from 'react';
-import { Meta, omit, Story, storyOf } from '../../../../../docs';
+import { Meta, omit, reactMatrix, Story } from '../../../../../docs';
+
+const disabled = [true, false] as const;
+const invalid = [true, false] as const;
+
+const type = [
+  'text',
+  'number',
+  'email',
+  'password',
+  'tel',
+  'url',
+  'search',
+] as const;
+type.toString = () => type.map((value) => `"${value}"`).join('|');
 
 export default {
   title: 'React/Input',
   component: Input,
   argTypes: {
-    ...omit<InputProps>('className', 'style'),
     children: {
       description: 'Acts as a label for an `<input>`.',
-      control: 'text',
-    },
-    placeholder: { control: 'text' },
-    invalid: {
-      table: { type: { summary: 'boolean' } },
     },
     disabled: {
       table: { type: { summary: 'boolean' } },
     },
+    invalid: {
+      table: { type: { summary: 'boolean' } },
+    },
+    placeholder: {
+      table: { type: { summary: 'string' } },
+    },
+    type: {
+      control: { type: 'radio', options: type },
+      table: {
+        type: { summary: type.toString() },
+        defaultValue: { summary: 'text' },
+      },
+    },
   },
   args: {
     children: 'Label',
-    placeholder: 'Placeholder',
-    invalid: false,
     disabled: false,
+    invalid: false,
+    placeholder: 'Placeholder',
+    type: 'text',
   },
+  parameters: { display: 'flex' },
 } as Meta<InputProps>;
 
 export const Playground: Story<InputProps> = (props: InputProps) => (
   <Input {...props} />
 );
 
-export const Invalid = storyOf(Input, 'invalid', [true, false], {
-  labelMode: 'prop',
-  labelProp: 'defaultValue',
-});
+export const Invalid = reactMatrix(Input, { invalid });
 Invalid.argTypes = omit<InputProps>('invalid');
 
-export const Disabled = storyOf(Input, 'disabled', [true, false], {
-  labelMode: 'prop',
-  labelProp: 'defaultValue',
-});
+export const Disabled = reactMatrix(Input, { disabled });
 Disabled.argTypes = omit<InputProps>('disabled');
+
+export const WithoutLabel = (props: InputProps) => <Input {...props} />;
+WithoutLabel.argTypes = omit<InputProps>('children');
+WithoutLabel.args = {
+  children: null,
+};
 
 interface InputWithHelperTextProps extends InputProps {
   label: string;
@@ -57,10 +80,10 @@ interface InputWithHelperTextProps extends InputProps {
 export const WithHelperText = ({
   label,
   helperText,
-  ...restInputProps
+  ...restProps
 }: InputWithHelperTextProps) => (
   <Field>
-    <Input {...restInputProps}>
+    <Input {...restProps}>
       {label}
       <HelperText>{helperText}</HelperText>
     </Input>
@@ -79,27 +102,32 @@ interface InputWithValidationProps extends InputProps {
 }
 
 export const WithValidation = ({
-  label,
   validation,
   withIcon,
-  ...restInputProps
+  ...restProps
 }: InputWithValidationProps) => (
   <Field>
-    <Input {...restInputProps} invalid={Boolean(validation)}>
-      {label}
-    </Input>
+    <Input {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
       {validation}
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<InputWithHelperTextProps>(
-  'children',
-  'invalid',
-  'disabled'
-);
+WithValidation.argTypes = omit<InputWithHelperTextProps>('invalid', 'disabled');
 WithValidation.args = {
-  label: 'Label',
   validation: 'This field is not valid',
   withIcon: true,
 };
+
+export const AllCombinations = reactMatrix(
+  Input,
+  { disabled, invalid },
+  (props) => <Input {...props} value={value(props)} />
+);
+AllCombinations.parameters = {
+  display: 'grid',
+  columns: 'repeat(2, 1fr)',
+};
+
+const value = ({ disabled, invalid }: InputProps) =>
+  `${invalid ? 'invalid' : 'valid'} ${disabled ? 'disabled' : ''}`;


### PR DESCRIPTION
## Purpose

After https://github.com/onfido/castor/pull/249 HTML (+ CSS) stories can now be added to each component.

## Approach

Adding stories to Input component.

Please note this excludes stories that include FieldLabel and other components, as they're to come later with their stories.

## Testing

On Storybook.

## Risks

N/A
