### PR TITLE
docs: correct html textarea "resize", incl. story default value

### DIFF
--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -29,7 +29,7 @@ export default {
       control: { type: 'radio', options: resize },
       table: {
         type: { summary: resize.toString() },
-        defaultValue: { summary: 'text' },
+        defaultValue: { summary: 'vertical' },
       },
     },
     rows: {

--- a/packages/core/src/components/textarea/textarea.story.tsx
+++ b/packages/core/src/components/textarea/textarea.story.tsx
@@ -16,6 +16,6 @@ export const Textarea = ({
   html('textarea', {
     ...props,
     class: classy(c('textarea'), m({ invalid })),
-    resize,
     rows,
+    style: `resize: ${resize}`,
   });

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -39,7 +39,7 @@ export default {
       control: { type: 'radio', options: resize },
       table: {
         type: { summary: resize.toString() },
-        defaultValue: { summary: 'text' },
+        defaultValue: { summary: 'vertical' },
       },
     },
     rows: {


### PR DESCRIPTION
## Purpose

[HTML story of Textarea component](https://github.com/onfido/castor/pull/420) had [incorrect "resize" prop use](https://github.com/onfido/castor/pull/420#discussion_r588268211), that instead should have been applied as a `style`.

## Approach

Set "resize" via `style`, also fix default value on a story table.

Currently `style` is added simply as text value, however probably later might be good to have a helper function where objects could be passed.

## Testing

On Storybook, Textarea component HTML story.

## Risks

N/A
