### PR TITLE
docs: correct html input "value"

### DIFF
--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -19,6 +19,7 @@ export default {
   title: 'Core/Input',
   component: Input,
   argTypes: {
+    ...omit<InputProps>('value'),
     disabled: {
       table: { type: { summary: 'boolean' } },
     },


### PR DESCRIPTION
## Purpose

Core and React stories should match, setting "value" is not needed however because of HTML story type it was added to the story table.

## Approach

Omit "value" property for story.

## Testing

On Storybook.

## Risks

N/A
