### PR TITLE
docs: correct html textarea "value"

### DIFF
--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -16,6 +16,7 @@ export default {
   title: 'Core/Textarea',
   component: Textarea,
   argTypes: {
+    ...omit<TextareaProps>('value'),
     disabled: {
       table: { type: { summary: 'boolean' } },
     },


### PR DESCRIPTION
## Purpose

Core and React stories should match, setting "value" is not needed however because of HTML story type it was added to the story table.

## Approach

Omit "value" property for story.

## Testing

On Storybook.

## Risks

N/A
