### PR TITLE
docs: set html textarea story value as "children"

### DIFF
--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -64,7 +64,7 @@ Disabled.argTypes = omit<TextareaProps>('disabled');
 export const AllCombinations = htmlMatrix(
   Textarea,
   { disabled, invalid },
-  (props) => Textarea({ ...props, value: value(props) })
+  (props) => Textarea({ ...props, children: value(props) })
 );
 AllCombinations.parameters = {
   display: 'grid',

--- a/packages/core/src/components/textarea/textarea.story.tsx
+++ b/packages/core/src/components/textarea/textarea.story.tsx
@@ -3,8 +3,8 @@ import { html } from '../../../../../docs';
 import { c, classy, m } from '../../utils';
 
 export interface TextareaProps extends BaseProps {
+  children: string;
   rows?: number;
-  value?: string;
 }
 
 export const Textarea = ({


### PR DESCRIPTION
## Purpose

"value" to `<textarea>` element cannot be set via `value` prop as for React, instead it should be `children`.

## Approach

Use `children` to set value to `<textarea>` for HTML story.

If merged, https://github.com/onfido/castor/pull/424 is no longer needed.

## Testing

On Storybook.

## Risks

N/A
