### PR TITLE
docs: fix import of "color" helper

### DIFF
--- a/packages/core/src/components/icon/icon.story.tsx
+++ b/packages/core/src/components/icon/icon.story.tsx
@@ -1,4 +1,4 @@
-import { IconProps } from '@onfido/castor';
+import { color, IconProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
 import { c, classy } from '../../utils';
 


### PR DESCRIPTION
## Purpose

"color" helper is used but not imported.

## Approach

Import "color" helper from Castor.

## Testing

On Storybook, Icon component HTML story by changing icon fill color.

## Risks

N/A
