### PR TITLE
docs: improve button stories

### DIFF
--- a/packages/core/src/components/button/button.stories.ts
+++ b/packages/core/src/components/button/button.stories.ts
@@ -3,6 +3,10 @@ import { htmlMatrix, Meta, omit, Story } from '../../../../../docs';
 import { Icon } from '../icon/icon.story';
 import { Button, ButtonProps } from './button.story';
 
+const disabled = [true, false] as const;
+const kind = ['action', 'destructive'] as const;
+const variant = ['primary', 'secondary', 'tertiary'] as const;
+
 export default {
   title: 'Core/Button',
   component: Button,
@@ -23,20 +27,16 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<ButtonProps>;
 
-const disabled = [true, false] as const;
-const kind = ['action', 'destructive'] as const;
-const variant = ['primary', 'secondary', 'tertiary'] as const;
-
 export const Playground: Story<ButtonProps> = (props) => Button(props);
 
 export const Kind = htmlMatrix(Button, { kind });
-Kind.argTypes = omit<ButtonProps>('kind', 'children');
+Kind.argTypes = omit<ButtonProps>('kind');
 
 export const Variant = htmlMatrix(Button, { variant });
-Variant.argTypes = omit<ButtonProps>('variant', 'children');
+Variant.argTypes = omit<ButtonProps>('variant');
 
 export const Disabled = htmlMatrix(Button, { disabled });
-Disabled.argTypes = omit<ButtonProps>('disabled', 'children');
+Disabled.argTypes = omit<ButtonProps>('disabled');
 
 export const AsAnchor: Story<ButtonProps> = (props) =>
   Button({ ...props, href: 'javascript:void 0' });

--- a/packages/core/src/components/button/button.ts
+++ b/packages/core/src/components/button/button.ts
@@ -1,5 +1,5 @@
 export interface ButtonProps {
+  disabled?: boolean;
   kind?: 'action' | 'destructive';
   variant?: 'primary' | 'secondary' | 'tertiary';
-  disabled?: boolean;
 }

--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -3,6 +3,10 @@ import { Button, ButtonProps, Icon } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, omit, reactMatrix, Story } from '../../../../../docs';
 
+const disabled = [true, false] as const;
+const kind = ['action', 'destructive'] as const;
+const variant = ['primary', 'secondary', 'tertiary'] as const;
+
 export default {
   title: 'React/Button',
   component: Button,
@@ -23,10 +27,6 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<ButtonProps>;
 
-const disabled = [true, false] as const;
-const kind = ['action', 'destructive'] as const;
-const variant = ['primary', 'secondary', 'tertiary'] as const;
-
 export const Playground: Story<ButtonProps<'a'>> = ({ href, ...restProps }) => (
   <Button
     {...restProps}
@@ -36,13 +36,13 @@ export const Playground: Story<ButtonProps<'a'>> = ({ href, ...restProps }) => (
 );
 
 export const Kind = reactMatrix(Button, { kind });
-Kind.argTypes = omit<ButtonProps>('kind', 'children');
+Kind.argTypes = omit<ButtonProps>('kind');
 
 export const Variant = reactMatrix(Button, { variant });
-Variant.argTypes = omit<ButtonProps>('variant', 'children');
+Variant.argTypes = omit<ButtonProps>('variant');
 
 export const Disabled = reactMatrix(Button, { disabled });
-Disabled.argTypes = omit<ButtonProps>('disabled', 'children');
+Disabled.argTypes = omit<ButtonProps>('disabled');
 
 export const AsAnchor: Story<ButtonProps<'a'>> = (props) => (
   <Button href="javascript:void 0" {...props} />
@@ -72,7 +72,6 @@ export const WithIcon: Story<ButtonWithIconProps> = ({
   </>
 );
 WithIcon.argTypes = {
-  ...omit<ButtonWithIconProps>('children'),
   iconName: { control: { type: 'select', options: iconNames } },
 };
 WithIcon.args = {


### PR DESCRIPTION
## Purpose

Make some improvements to Button component stories.

## Approach

Because of changed internal API for how stories are created, no longer needed to exclude "children" as it's now possible to change them in a story manually (instead of default "Button" value).

Also, type sorted alphabetically, and prop variation constants moved to the top to better align with new Input and Textarea component stories.

## Testing

On Storybook, both "core" and "react" stories for Button component.

## Risks

N/A
