### PR TITLE
fix: correct pointer for checkbox/radio component label (text)

### DIFF
--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -151,6 +151,7 @@
   // container children
   .ods-input-indicator ~ * {
     margin-right: helpers.space(2) - $padding;
+    pointer-events: none;
     position: relative;
   }
 }


### PR DESCRIPTION
## Purpose

Label (text) has no correct pointer required on Checkbox and Radio components (incl. "disabled" state).

## Approach

Remove pointer events for label text (children), allow pointer to be inherit from parent.

## Testing

On Storybook.

## Risks

If a link is to be added (although it's not recommended), it should then place the pointer events back for that link element.
