### PR TITLE
ci: commitlint exclude dependabot (preview)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run commitlint
-        if: github.actor != 'dependabot[bot]' # allow long commit message body
+        if: github.actor != 'dependabot-preview[bot]' # allow long commit message body
         run: npm run lint:commit
 
       - name: Run stylelint


### PR DESCRIPTION
## Purpose

Fixed on https://github.com/onfido/castor/pull/131, regression from https://github.com/onfido/castor/pull/442.

## Approach

Exclude `dependabot-preview[bot]` instead of `dependabot[bot]`.

## Testing

Only after merge - rebased [Dependabot PR](https://github.com/onfido/castor/pull/443) should not be failing anymore.

## Risks

N/A
