### PR TITLE
feat: default spinner as "medium" size

### DIFF
--- a/packages/core/src/components/spinner/spinner.story.tsx
+++ b/packages/core/src/components/spinner/spinner.story.tsx
@@ -6,7 +6,7 @@ export interface SpinnerProps extends BaseProps {
   children: string;
 }
 
-export const Spinner = ({ size = 'large', ...props }: SpinnerProps) =>
+export const Spinner = ({ size = 'medium', ...props }: SpinnerProps) =>
   html('div', {
     ...props,
     class: classy(c('spinner'), m(size)),

--- a/packages/react/src/components/spinner/spinner.tsx
+++ b/packages/react/src/components/spinner/spinner.tsx
@@ -2,7 +2,7 @@ import { c, classy, m, SpinnerProps as BaseProps } from '@onfido/castor';
 import React from 'react';
 
 export const Spinner = ({
-  size = 'large',
+  size = 'medium',
   children,
   className,
   ...restProps


### PR DESCRIPTION
## Purpose

Default Spinner component to "medium" size.

## Approach

Set default on React component, for HTML + CSS just default on a story.

## Testing

On Storybook.

## Risks

None - not yet released component.
