### PR TITLE
docs: display "color" selection options in description

### DIFF
--- a/packages/core/src/components/icon/icon.stories.ts
+++ b/packages/core/src/components/icon/icon.stories.ts
@@ -9,7 +9,12 @@ export default {
   title: 'Core/Icon',
   component: Icon,
   argTypes: {
-    color: { control: { type: 'select', options: colors } },
+    color: {
+      control: { type: 'select', options: colors },
+      table: {
+        type: { summary: colors.map((value) => `"${value}"`).join('|') },
+      },
+    },
   },
   args: {
     name: firstIconName,

--- a/packages/react/src/components/icon/icon.stories.tsx
+++ b/packages/react/src/components/icon/icon.stories.tsx
@@ -9,7 +9,12 @@ export default {
   title: 'React/Icon',
   component: Icon,
   argTypes: {
-    color: { control: { type: 'select', options: colors } },
+    color: {
+      control: { type: 'select', options: colors },
+      table: {
+        type: { summary: colors.map((value) => `"${value}"`).join('|') },
+      },
+    },
   },
   args: {
     name: firstIconName,


### PR DESCRIPTION
## Purpose

"color" for Icon component has a list of available colors to apply, however Core story does not list colors properly.

## Approach

Manually set table properties for both Core and React stories so that lists of colors available are aligned.

## Testing

On Storybook, Icon component of each Core and React stories.

## Risks

N/A
