### PR TITLE
fix: align field label width with input/textarea

### DIFF
--- a/packages/core/src/components/field-label/field-label.scss
+++ b/packages/core/src/components/field-label/field-label.scss
@@ -8,6 +8,7 @@
     display: flex;
     flex-flow: column wrap;
     padding: helpers.space(0.5) 0;
+    width: 100%;
 
     > .ods-input,
     > .ods-textarea {


### PR DESCRIPTION
## Purpose

Align FieldLabel width to be same as Input, which [recently changed to be 100%](https://github.com/onfido/castor/pull/439).

## Approach

Set FieldLabel to also be 100%, so e.g. in case when it wraps an Input (or Textarea) component it could span to that wanted 100%.

## Testing

On Storybook, inspecting React's Input and Textarea component stories that should be 100% and match Core stories.

## Risks

N/A
