### PR TITLE
fix: form grid styles and story radios

### DIFF
--- a/packages/core/src/components/form/form.scss
+++ b/packages/core/src/components/form/form.scss
@@ -5,6 +5,7 @@
     display: grid;
     gap: helpers.space(2);
     grid: auto-flow / 1fr;
+    justify-items: start;
 
     &.-disabled a {
       pointer-events: none;

--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -95,7 +95,12 @@ export const Playground: Story<FormProps<Values>> = (props) => (
       </div>
     </Field>
 
-    <Fieldset>
+    <Fieldset
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
       <FieldsetLegend>How did you hear about us?</FieldsetLegend>
       <Radio name="source">
         Social media


### PR DESCRIPTION
## Purpose

Fixes:
1. Form grid styles, so that children justify at start instead of stretching
2. Form story radios, so that they stack above each other

## Approach

1. Apply `justify-items: start`
2. Display radio fieldset as column flex

## Testing

Storybook. First issue was only observable in Firefox.

## Risks

None.
