### PR TITLE
docs: clean headings for better index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Castor &middot; [![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](https://onfido.github.io/castor/)
+# Castor
+
+[![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](https://onfido.github.io/castor/)
 
 _Castor_ is Onfido's design system. It is intended to support different renderers, and plain HTML + CSS.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,6 @@
-# Castor &middot; [![npm version](https://img.shields.io/npm/v/@onfido/castor.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor)
+# Castor
+
+[![npm version](https://img.shields.io/npm/v/@onfido/castor.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor)
 
 _Castor_ is Onfido's design system.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,4 +1,6 @@
-# Castor React &middot; [![npm version](https://img.shields.io/npm/v/@onfido/castor-react.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-react)
+# Castor React
+
+[![npm version](https://img.shields.io/npm/v/@onfido/castor-react.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-react)
 
 _Castor React_ is Onfido's design system addition. It provides [React](https://reactjs.org/) component library.
 


### PR DESCRIPTION
## Purpose

After GitHub introducing built-in index (table of content), our current headings included additional symbols resulting in odd appearance in UI:

![Screenshot 2021-04-06 at 10 50 47](https://user-images.githubusercontent.com/20243687/113692917-f3ec3780-96c5-11eb-8e53-137578a7ddd6.png)

## Approach

Move "dot" alongside badge to a newline after the heading on root and each package.

## Testing

On https://github.com/onfido/castor/tree/docs/better-gh-index (root and also each package).

## Risks

N/A
