### PR TITLE
docs: add list of supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 _Castor_ is Onfido's design system. It is intended to support different renderers, and plain HTML + CSS.
 
+## Browser support
+
+| <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" /><br>Chrome | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" /><br>Safari | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" /><br>Firefox | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" /><br>Edge |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| last 2 versions                                                                                                                                          | last 2 versions                                                                                                                                          | last 2 versions                                                                                                                                              | last 2 versions                                                                                                                                  |
+
 ## Install packages
 
 For HTML + CSS only:


### PR DESCRIPTION
## Purpose

Add list of supported browsers (and versions).

This closes #243.

## Approach

Add list of Chrome, Safari, Firefox, Edge browsers that we support with 2 last versions.

## Testing

On https://github.com/onfido/castor/tree/docs/supported-browsers

## Risks

N/A
