### PR TITLE
docs: add badges to indicate bundle sizes

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,7 @@
 # Castor
 
-[![npm version](https://img.shields.io/npm/v/@onfido/castor.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor)
+[![npm version](https://badgen.net/npm/v/@onfido/castor)](https://www.npmjs.com/package/@onfido/castor)
+[![Bundle size](https://badgen.net/bundlephobia/minzip/@onfido/castor)](https://bundlephobia.com/result?p=@onfido/castor)
 
 _Castor_ is Onfido's design system.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,7 @@
 # Castor React
 
-[![npm version](https://img.shields.io/npm/v/@onfido/castor-react.svg?style=flat-square)](https://www.npmjs.com/package/@onfido/castor-react)
+[![npm version](https://badgen.net/npm/v/@onfido/castor-react)](https://www.npmjs.com/package/@onfido/castor-react)
+[![Bundle size](https://badgen.net/bundlephobia/minzip/@onfido/castor-react)](https://bundlephobia.com/result?p=@onfido/castor-react)
 
 _Castor React_ is Onfido's design system addition. It provides [React](https://reactjs.org/) component library.
 


### PR DESCRIPTION
## Purpose

New badges to indicate bundle sizes.

## Approach

Use [bundlephobia](https://github.com/pastelsky/bundlephobia) to analyze and display minzipped sizes.

## Testing

On https://github.com/onfido/castor/tree/docs/bundle-size-badge

## Risks

N/A
