### PR TITLE
docs: correctly link from react to core instructions

### DIFF
--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -13,7 +13,7 @@ _Castor React_ is Onfido's design system addition. It provides [React](https://r
 npm install @onfido/castor @onfido/castor-react
 ```
 
-Follow [Castor](https://github.com/onfido/castor) instructions for initial setup.
+Follow [Castor](https://github.com/onfido/castor/blob/main/packages/core) instructions for initial setup.
 
 If you plan to use Icon component, also install [Castor Icons](https://github.com/onfido/castor-icons) package:
 


### PR DESCRIPTION
## Purpose

React package instructions refer to core package installation, however to root repository instead of package itself.

## Approach

Change link to core package location.

## Testing

On GitHub itself: https://github.com/onfido/castor/tree/docs/link-from-react-to-core/packages/react

## Risks

This always links to `main` tree.
