### PR TITLE
fix(react): change button href check from key to value

### DIFF
--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -10,7 +10,7 @@ export const Button: ButtonComponent = ({
 }: ButtonProps<'a'> | ButtonProps<'button'>) => {
   const { disabled } = useField();
 
-  const Element = 'href' in restProps ? 'a' : 'button';
+  const Element = (restProps as ButtonProps<'a'>).href ? 'a' : 'button';
 
   return (
     <Element


### PR DESCRIPTION
## Purpose

Make sure `<Button href={undefined} />` renders a `<button>` and not an `<a>`.

`<Button href="" />` will now also render as `<button>`, as will any falsey value.

## Approach

Check `href` for value and not just the key presence.

## Testing

1. Go to https://onfido.github.io/castor/?path=/docs/react-button--all-combinations, no button is disabled as they all incorrectly render as `<a>`
2. Go to the same story (directly from url, navigating doesn't work) in this PR preview, the first rows should render as `<button>`

## Risks

None.
