### PR TITLE
chore: add nyc_output to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ package-lock.json
 # Repository specific
 .cache
 .castor*
+.nyc_output
 coverage
 dist
 packages/*/prototype.js*


### PR DESCRIPTION
## Purpose

Ignore nyc/istanbul/e2e output.

## Approach

Add to `.gitignore`

## Testing

`npm run e2e` to create files, `git status` should show no diff.

## Risks

None.
