### PR TITLE
fix(react): useField types

### DIFF
--- a/packages/react/src/components/field/useField.ts
+++ b/packages/react/src/components/field/useField.ts
@@ -8,11 +8,13 @@ export const useField = () => {
   const form = useForm();
   const field = useContext(FieldContext);
 
-  return { ...omitNullish(form), ...omitNullish(field) };
+  return { ...omitNullish(form), ...omitNullish(field) } as FieldState;
 };
 
 export const FieldProvider = FieldContext.Provider;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const omitNullish = (obj: Record<string, any>) =>
-  Object.fromEntries(Object.entries(obj).filter(([, value]) => value != null));
+const omitNullish = <T extends Record<string, any>>(obj: T) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value != null)
+  ) as Partial<T>;


### PR DESCRIPTION
## Purpose

Fixes the `useField` hook types, which are currently just a Record of any.

## Approach

Fix types on the helper function as well as the object return in `useField` itself.

## Testing

Call `useField()` somewhere and check the types before and after.

## Risks

None.
