### PR TITLE
feat(core): themes set color-scheme

### DIFF
--- a/packages/core/src/theme/theme.scss
+++ b/packages/core/src/theme/theme.scss
@@ -2,14 +2,17 @@
 @use '../mixins';
 @use './tokens' as castor;
 
-// ...$types: 'class' | 'raw';
+// ...$types: 'class' | 'dark' | 'raw';
 @mixin theme($name, $types...) {
   $class: list.index($types, 'class');
+  $dark: list.index($types, 'dark');
   $raw: list.index($types, 'raw');
 
   $selector: if($class, '.castor-theme--#{$name}', null);
 
   @include mixins.wrap-if($selector) {
+    color-scheme: if($dark, 'dark', 'light');
+
     @if not $raw {
       @include castor.tokens();
     }

--- a/packages/core/src/theme/theme.scss
+++ b/packages/core/src/theme/theme.scss
@@ -2,17 +2,14 @@
 @use '../mixins';
 @use './tokens' as castor;
 
-// ...$types: 'class' | 'dark' | 'raw';
+// ...$types: 'class' | 'raw';
 @mixin theme($name, $types...) {
   $class: list.index($types, 'class');
-  $dark: list.index($types, 'dark');
   $raw: list.index($types, 'raw');
 
   $selector: if($class, '.castor-theme--#{$name}', null);
 
   @include mixins.wrap-if($selector) {
-    color-scheme: if($dark, 'dark', 'light');
-
     @if not $raw {
       @include castor.tokens();
     }

--- a/packages/core/src/theme/themes/day.scss
+++ b/packages/core/src/theme/themes/day.scss
@@ -4,6 +4,9 @@
 @mixin day($types...) {
   // prettier-ignore
   @include castor.theme('day', $types...) {
+    color-scheme: light;
+    
+    /* stylelint-disable-next-line order/order */
     --ods-transition-duration: 0.15s;
 
     --ods-color-content-main: var(--ods-color-neutral-800), 1;

--- a/packages/core/src/theme/themes/night.scss
+++ b/packages/core/src/theme/themes/night.scss
@@ -3,7 +3,10 @@
 // ...$types: 'class' | 'raw';
 @mixin night($types...) {
   // prettier-ignore
-  @include castor.theme('night', 'dark', $types...) {
+  @include castor.theme('night', $types...) {
+    color-scheme: dark;
+    
+    /* stylelint-disable-next-line order/order */
     --ods-transition-duration: 0.15s;
 
     --ods-color-content-main: var(--ods-color-neutral-200), 1;

--- a/packages/core/src/theme/themes/night.scss
+++ b/packages/core/src/theme/themes/night.scss
@@ -3,7 +3,7 @@
 // ...$types: 'class' | 'raw';
 @mixin night($types...) {
   // prettier-ignore
-  @include castor.theme('night', $types...) {
+  @include castor.theme('night', 'dark', $types...) {
     --ods-transition-duration: 0.15s;
 
     --ods-color-content-main: var(--ods-color-neutral-200), 1;


### PR DESCRIPTION
## Purpose

Currently the browser appearance does not adapt to Castor's set theme.

Most visible on a scrollbar:
![image](https://user-images.githubusercontent.com/18623773/115419419-39465400-a1f2-11eb-887d-2729304b4f75.png)

Make it so ([browsers that support it](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme#browser_compatibility)) do:
![image](https://user-images.githubusercontent.com/18623773/115419585-5b3fd680-a1f2-11eb-956b-ef312c2e3715.png)


## Approach

Extend the theme mixin to respond to a `dark` type, adding `color-scheme` accordingly.

## Testing

Look at the output `themes/night.css` and `day.css`.

## Risks

Some browsers like Firefox don't support it, but it should simply be ignored.
