### PR TITLE
fix(core): monospace font

### DIFF
--- a/packages/core/src/helpers/font/font.scss
+++ b/packages/core/src/helpers/font/font.scss
@@ -81,7 +81,7 @@ $_types: (
     text-transform: uppercase,
   ),
   'mono': (
-    font-family: '"Roboto Mono", monospace',
+    font-family: string.unquote('"Roboto Mono", monospace'),
   ),
 );
 


### PR DESCRIPTION
## Purpose

Currently the monospace font definition is wrapped in quotes, so the font-family does not apply.

![image](https://user-images.githubusercontent.com/18623773/115444138-1b85e880-a20c-11eb-9109-07f9a4e5b38c.png)

![image](https://user-images.githubusercontent.com/18623773/115444207-30627c00-a20c-11eb-90c6-9b347c963eec.png)

This unwraps the string so that it works.

## Approach

`string.unquote` in Sass.

## Testing

`@include castor.font('400-monospace')` should apply correctly.

## Risks

None.
