### PR TITLE
chore: configure stylelint with vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": ["esbenp.prettier-vscode", "stylelint.vscode-stylelint"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,18 @@
 {
+  "[css]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": true
+    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
   "[handlebars]": {
     "editor.formatOnSave": false
   },
   "[html]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": true
+    },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
@@ -15,6 +25,13 @@
     "editor.formatOnSave": true
   },
   "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[scss]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.stylelint": true
+    },
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },


### PR DESCRIPTION
## Purpose

We use `stylelint` however for VS Code it requires additional configuration and a plugin.

## Approach

Set the recommended plugin of `stylelint`, then add configuration to auto format and fix styling upon saving (only HTML, CSS, SCSS).

## Testing

Locally with VS Code.

## Risks

Only affects VS Code users, hopefully contributers will be using this editor and installing recommended plugins.
