### PR TITLE
chore: configure rulers for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
   },
+  "editor.rulers": [80],
   "editor.tabSize": 2,
   "html.format.endWithNewline": true,
   "html.format.indentHandlebars": true,


### PR DESCRIPTION
## Purpose

We do try to fit code into 80 characters long (which is done by linters), however having a visual line would also allow to keep such for other stuff like inline comments.

## Approach

Add ruler of 80 characters to VS Code.

## Testing

Locally on VS Code.

## Risks

Only affects users that would use VS Code.
