### PR TITLE
docs(react): always set href for button even when it's empty string

### DIFF
--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -27,12 +27,8 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<ButtonProps>;
 
-export const Playground: Story<ButtonProps<'a'>> = ({ href, ...restProps }) => (
-  <Button
-    {...restProps}
-    // don't set "href" key when value is empty string
-    {...(href && { href })}
-  />
+export const Playground: Story<ButtonProps<'a'>> = (props) => (
+  <Button {...props} />
 );
 
 export const Kind = reactMatrix(Button, { kind });


### PR DESCRIPTION
## Purpose

After https://github.com/onfido/castor/pull/576 no longer need to set "href" prop on React story _only_ when it's not empty, component will not render as `<a>` now if href is set empty.

## Approach

Pass all props to Button component.

## Testing

On Storybook, React story for Button component should render as `<button>` when "href" prop is empty.

## Risks

N/A
