### PR TITLE
docs(react): no "label" prop for input/textarea with validation stories

### DIFF
--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -96,7 +96,6 @@ WithHelperText.args = {
 };
 
 interface InputWithValidationProps extends InputProps {
-  label: string;
   validation: string;
   withIcon: boolean;
 }
@@ -113,7 +112,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<InputWithHelperTextProps>('invalid', 'disabled');
+WithValidation.argTypes = omit<InputWithValidationProps>('invalid', 'disabled');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -104,7 +104,6 @@ WithHelperText.args = {
 };
 
 interface TextareaWithValidationProps extends TextareaProps {
-  label: string;
   validation: string;
   withIcon: boolean;
 }


### PR DESCRIPTION
## Purpose

React Input & Textarea component stories "with validation" also has a "label" prop that is not needed, instead "children" should be used.

## Approach

Remove extra "label" prop added to stories.

## Testing

On Storybook, inspecting "with validation" React stories of Input and also Textarea components.

## Risks

N/A
