### PR TITLE
docs(react): always select default radio

### DIFF
--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -23,6 +23,8 @@ export default {
   args: {
     children: 'Button',
     disabled: false,
+    kind: 'action',
+    variant: 'primary',
   },
   parameters: { display: 'flex' },
 } as Meta<ButtonProps>;

--- a/packages/react/src/components/spinner/spinner.stories.tsx
+++ b/packages/react/src/components/spinner/spinner.stories.tsx
@@ -14,6 +14,7 @@ export default {
   },
   args: {
     children: 'Label',
+    size: 'medium',
   },
   parameters: { display: 'flex' },
 } as Meta<SpinnerProps>;


### PR DESCRIPTION
## Purpose

After some Storybook upgrade a default radio is no longer being selected.

## Approach

Use args to set the default, which then always selects it on a story.

## Testing

Button and Spinner components, React stories on Storybook.

## Risks

N/A

