### PR TITLE
docs(react): correct example of field validation, "minLength" prop

### DIFF
--- a/packages/react/src/components/field/field.tsx
+++ b/packages/react/src/components/field/field.tsx
@@ -10,12 +10,12 @@ export { useField } from './useField';
  *
  * @example
  * <Field>
- *   <Input minlength={3} required />
+ *   <Input minLength={3} required />
  *   <Validation state="error" if="valueMissing">
  *     Will show if [required] is invalid.
  *   </Validation>
  *   <Validation state="error" if="tooShort">
- *     Will show if [minlength] is invalid.
+ *     Will show if [minLength] is invalid.
  *   </Validation>
  * </Field>
  */


### PR DESCRIPTION
## Purpose

React uses "minLength" prop, not "minlength" attribute.

## Approach

Correct example with "minLength" prop.

## Testing

N/A

## Risks

N/A
