### PR TITLE
fix(react): form onSubmit values

### DIFF
--- a/packages/react/src/components/form/getFormValues.spec.ts
+++ b/packages/react/src/components/form/getFormValues.spec.ts
@@ -2,19 +2,20 @@ import { describe, expect, it } from '@jest/globals';
 import { getFormValues } from './getFormValues';
 
 describe('getFormValues', () => {
-  it('should return an object with name:value pairs from elements in a <form>', () => {
+  it('should return an object with [name, value] pairs from elements in a <form>', () => {
     const form = {
-      elements: {
-        foo: { value: {} },
-        bar: { value: [] },
-      },
+      elements: [
+        { name: 'foo', value: {} },
+        { value: 1 },
+        { name: 'bar', value: [] },
+      ],
     };
 
     const result = getFormValues(form as any);
 
     expect(result).toStrictEqual({
-      foo: form.elements.foo.value,
-      bar: form.elements.bar.value,
+      foo: form.elements[0].value,
+      bar: form.elements[2].value,
     });
   });
 });

--- a/packages/react/src/components/form/getFormValues.ts
+++ b/packages/react/src/components/form/getFormValues.ts
@@ -13,14 +13,10 @@
  */
 export const getFormValues = <T extends Result>(form: HTMLFormElement): T =>
   Object.fromEntries(
-    Object.entries(form.elements).filter(hasName).map(elementValue)
-  );
+    (Array.from(form.elements) as HTMLInputElement[])
+      .filter((el) => !!el.name)
+      .map((el) => [el.name, el.value])
+  ) as T;
 
-const hasName = ([key]: Entry) => !isDigit.test(key);
-const elementValue = ([key, element]: Entry) => [key, valueOf(element)];
-const valueOf = (element: Element) => (element as HTMLFormElement).value;
-const isDigit = /^\d$/;
-
-type Entry = [string, Element];
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Result = Record<string, any>;

--- a/packages/react/src/components/form/getFormValues.ts
+++ b/packages/react/src/components/form/getFormValues.ts
@@ -13,10 +13,15 @@
  */
 export const getFormValues = <T extends Result>(form: HTMLFormElement): T =>
   Object.fromEntries(
-    (Array.from(form.elements) as HTMLInputElement[])
+    (Array.from(form.elements) as HTMLNamedElement[])
       .filter((el) => !!el.name)
       .map((el) => [el.name, el.value])
   ) as T;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Result = Record<string, any>;
+
+interface HTMLNamedElement extends HTMLElement {
+  name: string;
+  value: string;
+}


### PR DESCRIPTION
## Purpose

The current approach will read `id` off elements if they have one, instead of reading their `names`.

That's because of how `<form>.elements` work.

![image](https://user-images.githubusercontent.com/18623773/115912871-cb0ac700-a467-11eb-926f-30ac26204cef.png)

## Approach

Instead of using the `elements` key, just list them as an array and filter the ones that have the `name` property set.
It's actually much more efficient this way, and we can remove some code.

## Testing

Updated unit tests.

## Risks

None.
