### PR TITLE
feat(core): improve font monospace list

### DIFF
--- a/packages/core/src/helpers/font/font.scss
+++ b/packages/core/src/helpers/font/font.scss
@@ -81,7 +81,7 @@ $_types: (
     text-transform: uppercase,
   ),
   'mono': (
-    font-family: string.unquote('"Roboto Mono", monospace'),
+    font-family: string.unquote('"Roboto Mono", Consolas, Menlo, monospace'),
   ),
 );
 

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -71,5 +71,5 @@ const types = {
   regular: { fontWeight: 400 },
   light: { fontWeight: 300 },
   allcaps: { textTransform: 'uppercase' },
-  mono: { fontFamily: '"Roboto Mono", monospace' },
+  mono: { fontFamily: '"Roboto Mono", Consolas, Menlo, monospace' },
 };


### PR DESCRIPTION
## Purpose

When "Roboto Mono" is not available, the default `monospace` font in Chrome/MacOS is [Courier](https://en.wikipedia.org/wiki/Courier_(typeface)), which is a serif font and looks nothing like Roboto.

So, this improves the monospace list in case "Roboto Mono" isn't available.

## Approach

Add `Consolas` for Windows and `Menlo` for MacOS.

## Testing

Use monospace font helpers but don't provide "Roboto Mono".

## Risks

None.
