### PR TITLE
feat(react): deprecate "children" for adding input/textarea label

### DIFF
--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -35,27 +35,46 @@ interface Values {
 export const Playground: Story<FormProps<Values>> = (props) => (
   <Form {...props}>
     <Field>
-      <Input name="firstName" required>
-        First name <Asterisk aria-label="required" />
-      </Input>
+      <Input
+        name="firstName"
+        label={
+          <>
+            First name <Asterisk aria-label="required" />
+          </>
+        }
+        required
+      />
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>
     </Field>
 
     <Field>
-      <Input name="lastName" required>
-        Last name <Asterisk aria-label="required" />
-      </Input>
+      <Input
+        name="lastName"
+        label={
+          <>
+            Last name <Asterisk aria-label="required" />
+          </>
+        }
+        required
+      />
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>
     </Field>
 
     <Field>
-      <Input type="email" name="email" required>
-        Email address <Asterisk aria-label="required" />
-      </Input>
+      <Input
+        type="email"
+        name="email"
+        label={
+          <>
+            Email address <Asterisk aria-label="required" />
+          </>
+        }
+        required
+      />
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>

--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -35,46 +35,36 @@ interface Values {
 export const Playground: Story<FormProps<Values>> = (props) => (
   <Form {...props}>
     <Field>
-      <Input
-        name="firstName"
-        label={
-          <>
-            First name <Asterisk aria-label="required" />
-          </>
-        }
-        required
-      />
+      <FieldLabel>
+        <span>
+          First name <Asterisk aria-label="required" />
+        </span>
+        <Input name="firstName" required />
+      </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>
     </Field>
 
     <Field>
-      <Input
-        name="lastName"
-        label={
-          <>
-            Last name <Asterisk aria-label="required" />
-          </>
-        }
-        required
-      />
+      <FieldLabel>
+        <span>
+          Last name <Asterisk aria-label="required" />
+        </span>
+        <Input name="lastName" required />
+      </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>
     </Field>
 
     <Field>
-      <Input
-        type="email"
-        name="email"
-        label={
-          <>
-            Email address <Asterisk aria-label="required" />
-          </>
-        }
-        required
-      />
+      <FieldLabel>
+        <span>
+          Email address <Asterisk aria-label="required" />
+        </span>
+        <Input type="email" name="email" required />
+      </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field
       </Validation>

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -1,5 +1,6 @@
 import {
   Field,
+  FieldLabel,
   HelperText,
   Input,
   InputProps,
@@ -26,14 +27,14 @@ export default {
   title: 'React/Input',
   component: Input,
   argTypes: {
-    children: {
-      description: 'Acts as a label for an `<input>`.',
-    },
     disabled: {
       table: { type: { summary: 'boolean' } },
     },
     invalid: {
       table: { type: { summary: 'boolean' } },
+    },
+    label: {
+      description: 'Optional label for an `<input>`.',
     },
     placeholder: {
       table: { type: { summary: 'string' } },
@@ -47,9 +48,9 @@ export default {
     },
   },
   args: {
-    children: 'Label',
     disabled: false,
     invalid: false,
+    label: 'Label',
     placeholder: 'Placeholder',
     type: 'text',
   },
@@ -67,13 +68,12 @@ export const Disabled = reactMatrix(Input, { disabled });
 Disabled.argTypes = omit<InputProps>('disabled');
 
 export const WithoutLabel = (props: InputProps) => <Input {...props} />;
-WithoutLabel.argTypes = omit<InputProps>('children');
+WithoutLabel.argTypes = omit<InputProps>('label');
 WithoutLabel.args = {
-  children: null,
+  label: undefined,
 };
 
 interface InputWithHelperTextProps extends InputProps {
-  label: string;
   helperText: string;
 }
 
@@ -83,15 +83,14 @@ export const WithHelperText = ({
   ...restProps
 }: InputWithHelperTextProps) => (
   <Field>
-    <Input {...restProps}>
+    <FieldLabel>
       {label}
       <HelperText>{helperText}</HelperText>
-    </Input>
+      <Input {...restProps} />
+    </FieldLabel>
   </Field>
 );
-WithHelperText.argTypes = omit<InputWithHelperTextProps>('children');
 WithHelperText.args = {
-  label: 'Label',
   helperText: 'Helper text',
 };
 

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -33,9 +33,6 @@ export default {
     invalid: {
       table: { type: { summary: 'boolean' } },
     },
-    label: {
-      description: 'Optional label for an `<input>`.',
-    },
     placeholder: {
       table: { type: { summary: 'string' } },
     },
@@ -50,7 +47,6 @@ export default {
   args: {
     disabled: false,
     invalid: false,
-    label: 'Label',
     placeholder: 'Placeholder',
     type: 'text',
   },
@@ -67,21 +63,16 @@ Invalid.argTypes = omit<InputProps>('invalid');
 export const Disabled = reactMatrix(Input, { disabled });
 Disabled.argTypes = omit<InputProps>('disabled');
 
-export const WithoutLabel = (props: InputProps) => <Input {...props} />;
-WithoutLabel.argTypes = omit<InputProps>('label');
-WithoutLabel.args = {
-  label: undefined,
-};
-
-interface InputWithHelperTextProps extends InputProps {
+interface InputWithLabelAndHelperTextProps extends InputProps {
+  label: string;
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithLabelAndHelperText = ({
   label,
   helperText,
   ...restProps
-}: InputWithHelperTextProps) => (
+}: InputWithLabelAndHelperTextProps) => (
   <Field>
     <FieldLabel>
       {label}
@@ -90,7 +81,8 @@ export const WithHelperText = ({
     </FieldLabel>
   </Field>
 );
-WithHelperText.args = {
+WithLabelAndHelperText.args = {
+  label: 'Label',
   helperText: 'Helper text',
 };
 

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -46,7 +46,16 @@ Input.displayName = 'Input';
 
 export type InputProps = BaseProps &
   Omit<InputElementProps, 'children'> & {
-    /** @deprecated Use component composition instead */
+    /**
+     * @deprecated
+     * Use component composition instead.
+     *
+     * @example
+     * <FieldLabel>
+     *   My Label
+     *   <Input name="my-input" />
+     * </FieldLabel>
+     */
     children?: InputElementProps['children'];
   };
 

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -1,6 +1,6 @@
 import { c, classy, InputProps as BaseProps, m } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { FieldLabelWrapper } from '../../internal';
 import { withRef } from '../../utils';
 
@@ -50,8 +50,7 @@ export type InputProps = BaseProps &
   Omit<InputElementProps, 'children'> & {
     /** @deprecated Use `label` prop instead */
     children?: InputElementProps['children'];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    label?: any;
+    label?: ReactNode;
   };
 
 type InputElementProps = JSX.IntrinsicElements['input'];

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -13,6 +13,7 @@ export const Input = withRef(
       id: externalId,
       type = 'text',
       invalid,
+      label: externalLabel,
       children,
       className,
       ...restProps
@@ -20,13 +21,14 @@ export const Input = withRef(
     ref: InputProps['ref']
   ): JSX.Element => {
     const { disabled, touched } = useField();
+    const label = externalLabel || children;
     const [autoId] = useState(() => `${idPrefix}_${++idCount}`);
-    const id = externalId || (children ? autoId : undefined);
+    const id = externalId || (label ? autoId : undefined);
 
     return (
       <FieldLabelWrapper id={id}>
         {{
-          children,
+          label,
           element: (
             <input
               disabled={disabled} // will be overriden by props if set
@@ -44,4 +46,12 @@ export const Input = withRef(
 );
 Input.displayName = 'Input';
 
-export type InputProps = BaseProps & JSX.IntrinsicElements['input'];
+export type InputProps = BaseProps &
+  Omit<InputElementProps, 'children'> & {
+    /** @deprecated Use `label` prop instead */
+    children?: InputElementProps['children'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    label?: any;
+  };
+
+type InputElementProps = JSX.IntrinsicElements['input'];

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -1,6 +1,6 @@
 import { c, classy, InputProps as BaseProps, m } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 import { FieldLabelWrapper } from '../../internal';
 import { withRef } from '../../utils';
 
@@ -13,7 +13,6 @@ export const Input = withRef(
       id: externalId,
       type = 'text',
       invalid,
-      label: externalLabel,
       children,
       className,
       ...restProps
@@ -21,14 +20,13 @@ export const Input = withRef(
     ref: InputProps['ref']
   ): JSX.Element => {
     const { disabled, touched } = useField();
-    const label = externalLabel || children;
     const [autoId] = useState(() => `${idPrefix}_${++idCount}`);
-    const id = externalId || (label ? autoId : undefined);
+    const id = externalId || (children ? autoId : undefined);
 
     return (
       <FieldLabelWrapper id={id}>
         {{
-          label,
+          children,
           element: (
             <input
               disabled={disabled} // will be overriden by props if set
@@ -48,9 +46,8 @@ Input.displayName = 'Input';
 
 export type InputProps = BaseProps &
   Omit<InputElementProps, 'children'> & {
-    /** @deprecated Use `label` prop instead */
+    /** @deprecated Use component composition instead */
     children?: InputElementProps['children'];
-    label?: ReactNode;
   };
 
 type InputElementProps = JSX.IntrinsicElements['input'];

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -30,9 +30,6 @@ export default {
     invalid: {
       table: { type: { summary: 'boolean' } },
     },
-    label: {
-      description: 'Optional label for an `<textarea>`.',
-    },
     placeholder: {
       table: { type: { summary: 'string' } },
     },
@@ -54,7 +51,6 @@ export default {
   args: {
     disabled: false,
     invalid: false,
-    label: 'Label',
     placeholder: 'Placeholder',
     resize: 'vertical',
     rows: 3,
@@ -75,21 +71,16 @@ Invalid.argTypes = omit<TextareaProps>('invalid');
 export const Disabled = reactMatrix(Textarea, { disabled });
 Disabled.argTypes = omit<TextareaProps>('disabled');
 
-export const WithoutLabel = (props: TextareaProps) => <Textarea {...props} />;
-WithoutLabel.argTypes = omit<TextareaProps>('label');
-WithoutLabel.args = {
-  label: undefined,
-};
-
-interface TextareaWithHelperTextProps extends TextareaProps {
+interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
+  label: string;
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithLabelAndHelperText = ({
   label,
   helperText,
   ...restProps
-}: TextareaWithHelperTextProps) => (
+}: TextareaWithLabelAndHelperTextProps) => (
   <Field>
     <FieldLabel>
       {label}
@@ -98,7 +89,8 @@ export const WithHelperText = ({
     </FieldLabel>
   </Field>
 );
-WithHelperText.args = {
+WithLabelAndHelperText.args = {
+  label: 'Label',
   helperText: 'Helper text',
 };
 

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -1,5 +1,6 @@
 import {
   Field,
+  FieldLabel,
   HelperText,
   Textarea,
   TextareaProps,
@@ -23,14 +24,14 @@ export default {
   title: 'React/Textarea',
   component: Textarea,
   argTypes: {
-    children: {
-      description: 'Acts as a label for a `<textarea>`.',
-    },
     disabled: {
       table: { type: { summary: 'boolean' } },
     },
     invalid: {
       table: { type: { summary: 'boolean' } },
+    },
+    label: {
+      description: 'Optional label for an `<textarea>`.',
     },
     placeholder: {
       table: { type: { summary: 'string' } },
@@ -51,9 +52,9 @@ export default {
     },
   },
   args: {
-    children: 'Label',
     disabled: false,
     invalid: false,
+    label: 'Label',
     placeholder: 'Placeholder',
     resize: 'vertical',
     rows: 3,
@@ -75,13 +76,12 @@ export const Disabled = reactMatrix(Textarea, { disabled });
 Disabled.argTypes = omit<TextareaProps>('disabled');
 
 export const WithoutLabel = (props: TextareaProps) => <Textarea {...props} />;
-WithoutLabel.argTypes = omit<TextareaProps>('children');
+WithoutLabel.argTypes = omit<TextareaProps>('label');
 WithoutLabel.args = {
-  children: null,
+  label: undefined,
 };
 
 interface TextareaWithHelperTextProps extends TextareaProps {
-  label: string;
   helperText: string;
 }
 
@@ -91,15 +91,14 @@ export const WithHelperText = ({
   ...restProps
 }: TextareaWithHelperTextProps) => (
   <Field>
-    <Textarea {...restProps}>
+    <FieldLabel>
       {label}
       <HelperText>{helperText}</HelperText>
-    </Textarea>
+      <Textarea {...restProps} />
+    </FieldLabel>
   </Field>
 );
-WithHelperText.argTypes = omit<TextareaWithHelperTextProps>('children');
 WithHelperText.args = {
-  label: 'Label',
   helperText: 'Helper text',
 };
 

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -14,6 +14,7 @@ export const Textarea = withRef(
       resize = 'vertical',
       rows = 3,
       invalid,
+      label: externalLabel,
       children,
       className,
       style,
@@ -22,13 +23,14 @@ export const Textarea = withRef(
     ref: TextareaProps['ref']
   ): JSX.Element => {
     const { disabled, touched } = useField();
+    const label = externalLabel || children;
     const [autoId] = useState(() => `${idPrefix}_${++idCount}`);
-    const id = externalId || (children ? autoId : undefined);
+    const id = externalId || (label ? autoId : undefined);
 
     return (
       <FieldLabelWrapper id={id}>
         {{
-          children,
+          label,
           element: (
             <textarea
               disabled={disabled} // will be overriden by props if set
@@ -51,4 +53,12 @@ export const Textarea = withRef(
 );
 Textarea.displayName = 'Textarea';
 
-export type TextareaProps = BaseProps & JSX.IntrinsicElements['textarea'];
+export type TextareaProps = BaseProps &
+  Omit<TextareaElementProps, 'children'> & {
+    /** @deprecated Use `label` prop instead */
+    children?: TextareaElementProps['children'];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    label?: any;
+  };
+
+type TextareaElementProps = JSX.IntrinsicElements['textarea'];

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -53,7 +53,16 @@ Textarea.displayName = 'Textarea';
 
 export type TextareaProps = BaseProps &
   Omit<TextareaElementProps, 'children'> & {
-    /** @deprecated Use component composition instead */
+    /**
+     * @deprecated
+     * Use component composition instead.
+     *
+     * @example
+     * <FieldLabel>
+     *   My Label
+     *   <Textarea name="my-textarea" />
+     * </FieldLabel>
+     */
     children?: TextareaElementProps['children'];
   };
 

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -1,6 +1,6 @@
 import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
-import React, { ReactNode, useState } from 'react';
+import React, { useState } from 'react';
 import { FieldLabelWrapper } from '../../internal';
 import { withRef } from '../../utils';
 
@@ -14,7 +14,6 @@ export const Textarea = withRef(
       resize = 'vertical',
       rows = 3,
       invalid,
-      label: externalLabel,
       children,
       className,
       style,
@@ -23,14 +22,13 @@ export const Textarea = withRef(
     ref: TextareaProps['ref']
   ): JSX.Element => {
     const { disabled, touched } = useField();
-    const label = externalLabel || children;
     const [autoId] = useState(() => `${idPrefix}_${++idCount}`);
-    const id = externalId || (label ? autoId : undefined);
+    const id = externalId || (children ? autoId : undefined);
 
     return (
       <FieldLabelWrapper id={id}>
         {{
-          label,
+          children,
           element: (
             <textarea
               disabled={disabled} // will be overriden by props if set
@@ -55,9 +53,8 @@ Textarea.displayName = 'Textarea';
 
 export type TextareaProps = BaseProps &
   Omit<TextareaElementProps, 'children'> & {
-    /** @deprecated Use `label` prop instead */
+    /** @deprecated Use component composition instead */
     children?: TextareaElementProps['children'];
-    label?: ReactNode;
   };
 
 type TextareaElementProps = JSX.IntrinsicElements['textarea'];

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -1,6 +1,6 @@
 import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
-import React, { useState } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { FieldLabelWrapper } from '../../internal';
 import { withRef } from '../../utils';
 
@@ -57,8 +57,7 @@ export type TextareaProps = BaseProps &
   Omit<TextareaElementProps, 'children'> & {
     /** @deprecated Use `label` prop instead */
     children?: TextareaElementProps['children'];
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    label?: any;
+    label?: ReactNode;
   };
 
 type TextareaElementProps = JSX.IntrinsicElements['textarea'];

--- a/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
+++ b/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
@@ -1,19 +1,19 @@
 import { FieldLabel } from '@onfido/castor-react';
-import React, { ReactNode } from 'react';
+import React from 'react';
 
 /**
  * Wrapper for `Input` and `Textarea` components, using `FieldLabel` when
- * `label` prop is provided.
+ * children is provided.
  */
 export const FieldLabelWrapper = ({
   id,
-  children: { element, label },
+  children: { element, children },
 }: FieldLabelWrapperProps): JSX.Element => {
-  if (!label) return element;
+  if (!children) return element;
 
   return (
     <FieldLabel htmlFor={id}>
-      <span>{label}</span>
+      <span>{children}</span>
       {element}
     </FieldLabel>
   );
@@ -22,8 +22,8 @@ export const FieldLabelWrapper = ({
 export interface FieldLabelWrapperProps {
   id: InputElementProps['id'] | TextareaElementProps['id'];
   children: {
+    children: InputElementProps['children'] | TextareaElementProps['children'];
     element: JSX.Element;
-    label: ReactNode;
   };
 }
 

--- a/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
+++ b/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
@@ -1,5 +1,5 @@
 import { FieldLabel } from '@onfido/castor-react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 /**
  * Wrapper for `Input` and `Textarea` components, using `FieldLabel` when
@@ -23,8 +23,7 @@ export interface FieldLabelWrapperProps {
   id: InputElementProps['id'] | TextareaElementProps['id'];
   children: {
     element: JSX.Element;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    label: any;
+    label: ReactNode;
   };
 }
 

--- a/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
+++ b/packages/react/src/internal/field-label-wrapper/field-label-wrapper.tsx
@@ -3,17 +3,17 @@ import React from 'react';
 
 /**
  * Wrapper for `Input` and `Textarea` components, using `FieldLabel` when
- * children is provided.
+ * `label` prop is provided.
  */
 export const FieldLabelWrapper = ({
   id,
-  children: { element, children },
+  children: { element, label },
 }: FieldLabelWrapperProps): JSX.Element => {
-  if (!children) return element;
+  if (!label) return element;
 
   return (
     <FieldLabel htmlFor={id}>
-      <span>{children}</span>
+      <span>{label}</span>
       {element}
     </FieldLabel>
   );
@@ -22,8 +22,9 @@ export const FieldLabelWrapper = ({
 export interface FieldLabelWrapperProps {
   id: InputElementProps['id'] | TextareaElementProps['id'];
   children: {
-    children: InputElementProps['children'] | TextareaElementProps['children'];
     element: JSX.Element;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    label: any;
   };
 }
 


### PR DESCRIPTION
## Purpose

Using "children" prop to display a label on React's Input and Textarea is not very accurate, because "children" on Textarea has another meaning, also e.g. for Select component this also will not work - options will need to be provided via children instead.

## Approach

Deprecate usage of "children" prop on Input and Textarea components, suggest component composition instead.

## Testing

N/A

## Risks

N/A
