### PR TITLE
docs: wrap code in list with backticks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,11 +92,11 @@ For writing tests locally:
 
 1. You can serve the app in E2E mode with:
 
-   yarn e2e:serve
+   `yarn e2e:serve`
 
 2. Then in another terminal open Cypress with:
 
-   yarn cypress open
+   `yarn cypress open`
 
 Alternatively you could use a single terminal with:
 


### PR DESCRIPTION
## Purpose

On Markdown list with new line indentations code snippets do not get converted properly in UI.

## Approach

Wrap code snippets with backticks, same as on other places in the doc.

## Testing

On GitHub UI.

## Risks

N/A
