### PR TITLE
ci: use yarn to execute lint commands

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,13 +22,13 @@ jobs:
 
       - name: Run commitlint
         if: github.actor != 'dependabot-preview[bot]' # allow long commit message body
-        run: npm run lint:commit
+        run: yarn lint:commit
 
       - name: Run stylelint
-        run: npm run lint:style
+        run: yarn lint:style
 
       - name: Run ESLint
-        run: npm run lint:es
+        run: yarn lint:es
 
       - name: Run Prettier
-        run: npm run lint:prettier
+        run: yarn lint:prettier


### PR DESCRIPTION
## Purpose

Use Yarn always, as it's main dependency manager for this repository.

When running lint commands, due to a [recent change](https://github.com/onfido/castor/pull/442), npm is being used instead of Yarn.

## Approach

Use Yarn to execute lint commands on CI.

## Testing

N/A

## Risks

N/A
