### PR TITLE
refactor: import from package rather than relative path

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -16,6 +16,10 @@ export default {
       statements: 100,
     },
   },
+  moduleNameMapper: {
+    '^@onfido/castor$': '<rootDir>/core/src',
+    '^@onfido/castor-(.*)$': '<rootDir>/$1/src',
+  },
   preset: 'ts-jest',
   rootDir: 'packages',
   testEnvironment: 'jsdom',

--- a/packages/core/src/components/asterisk/asterisk.story.tsx
+++ b/packages/core/src/components/asterisk/asterisk.story.tsx
@@ -1,5 +1,5 @@
+import { c, classy } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy } from '../../utils';
 
 export interface AsteriskProps {
   'aria-label': string;

--- a/packages/core/src/components/button/button.story.tsx
+++ b/packages/core/src/components/button/button.story.tsx
@@ -1,6 +1,5 @@
-import { ButtonProps as BaseProps } from '@onfido/castor';
+import { ButtonProps as BaseProps, c, classy, m } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy, m } from '../../utils';
 
 export interface ButtonProps extends BaseProps {
   children: string;

--- a/packages/core/src/components/field-label/field-label.story.tsx
+++ b/packages/core/src/components/field-label/field-label.story.tsx
@@ -1,5 +1,5 @@
+import { c, classy } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy } from '../../utils';
 
 export interface FieldLabelProps {
   children: string | string[];

--- a/packages/core/src/components/field/field.story.tsx
+++ b/packages/core/src/components/field/field.story.tsx
@@ -1,5 +1,5 @@
+import { c, classy } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy } from '../../utils';
 
 export interface FieldProps {
   children: string | string[];

--- a/packages/core/src/components/helper-text/helper-text.story.tsx
+++ b/packages/core/src/components/helper-text/helper-text.story.tsx
@@ -1,6 +1,5 @@
-import { HelperTextProps as BaseProps, m } from '@onfido/castor';
+import { c, classy, HelperTextProps as BaseProps, m } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy } from '../../utils';
 
 export interface HelperTextProps extends BaseProps {
   children: string | string[];

--- a/packages/core/src/components/icon/icon.story.tsx
+++ b/packages/core/src/components/icon/icon.story.tsx
@@ -1,6 +1,5 @@
-import { color, IconProps } from '@onfido/castor';
+import { c, classy, color, IconProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy } from '../../utils';
 
 /**
  * `.ods-icon` requires SVG sprite to be included in your app.

--- a/packages/core/src/components/icon/icon.ts
+++ b/packages/core/src/components/icon/icon.ts
@@ -1,5 +1,5 @@
+import { Color } from '@onfido/castor';
 import { IconName } from '@onfido/castor-icons';
-import { Color } from '../../helpers';
 
 export interface IconProps {
   name: IconName;

--- a/packages/core/src/components/input/input.story.tsx
+++ b/packages/core/src/components/input/input.story.tsx
@@ -1,6 +1,5 @@
-import { InputProps as BaseProps } from '@onfido/castor';
+import { c, classy, InputProps as BaseProps, m } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy, m } from '../../utils';
 
 export interface InputProps extends BaseProps {
   id?: string;

--- a/packages/core/src/components/spinner/spinner.story.tsx
+++ b/packages/core/src/components/spinner/spinner.story.tsx
@@ -1,6 +1,5 @@
-import { SpinnerProps as BaseProps } from '@onfido/castor';
+import { c, classy, m, SpinnerProps as BaseProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy, m } from '../../utils';
 
 export interface SpinnerProps extends BaseProps {
   children: string;

--- a/packages/core/src/components/textarea/textarea.story.tsx
+++ b/packages/core/src/components/textarea/textarea.story.tsx
@@ -1,6 +1,5 @@
-import { TextareaProps as BaseProps } from '@onfido/castor';
+import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
-import { c, classy, m } from '../../utils';
 
 export interface TextareaProps extends BaseProps {
   children?: string;

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -1,5 +1,5 @@
+import { toCSS } from '@onfido/castor';
 import { CSSProperties } from 'react';
-import { toCSS } from '../../utils';
 
 /**
  * Returns an object that represents a `Font`.

--- a/packages/core/src/utils/toCSS/toCSS.spec.ts
+++ b/packages/core/src/utils/toCSS/toCSS.spec.ts
@@ -1,9 +1,5 @@
-import { describe, expect, it, jest } from '@jest/globals';
+import { describe, expect, it } from '@jest/globals';
 import { toCSS } from './toCSS';
-
-jest.mock('../../utils', () => ({
-  kebabCase: (s: string) => s.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase(),
-}));
 
 describe('toCSS', () => {
   it('should transform a style object correctly to CSS', () => {

--- a/packages/core/src/utils/toCSS/toCSS.ts
+++ b/packages/core/src/utils/toCSS/toCSS.ts
@@ -1,5 +1,4 @@
-import { Font } from '../../helpers';
-import { kebabCase } from '../../utils';
+import { Font, kebabCase } from '@onfido/castor';
 
 /**
  * Transforms a `Font` style object into a valid CSS string.

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,6 +1,6 @@
 import { ButtonProps as BaseProps, c, classy, m } from '@onfido/castor';
+import { useField } from '@onfido/castor-react';
 import React, { HTMLAttributes } from 'react';
-import { useField } from '../field/useField';
 
 export const Button: ButtonComponent = ({
   kind = 'action',

--- a/packages/react/src/components/field/useField.spec.ts
+++ b/packages/react/src/components/field/useField.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import { useForm } from '@onfido/castor-react';
 import { useContext } from 'react';
-import { useForm } from '../form/useForm';
 import { FieldProvider, useField } from './useField';
 
-jest.mock('../form/useForm', () => ({ useForm: jest.fn() }));
+jest.mock('@onfido/castor-react', () => ({ useForm: jest.fn() }));
 jest.mock('react', () => {
   const context = { Provider: {} };
   return {

--- a/packages/react/src/components/field/useField.ts
+++ b/packages/react/src/components/field/useField.ts
@@ -1,6 +1,6 @@
 import { FieldState } from '@onfido/castor';
+import { useForm } from '@onfido/castor-react';
 import { createContext, useContext } from 'react';
-import { useForm } from '../form/useForm';
 
 const FieldContext = createContext({} as FieldState);
 

--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -4,6 +4,8 @@ import {
   Checkbox,
   Field,
   FieldLabel,
+  Fieldset,
+  FieldsetLegend,
   Form,
   FormProps,
   HelperText,
@@ -13,8 +15,6 @@ import {
 } from '@onfido/castor-react';
 import React from 'react';
 import { Meta, Story } from '../../../../../docs';
-import { FieldsetLegend } from '../fieldset-legend/fieldset-legend';
-import { Fieldset } from '../fieldset/fieldset';
 
 export default {
   title: 'React/Form',

--- a/packages/react/src/components/search/search.tsx
+++ b/packages/react/src/components/search/search.tsx
@@ -1,8 +1,7 @@
 import { c, classy } from '@onfido/castor';
-import { Icon } from '@onfido/castor-react';
+import { Icon, Input, InputProps } from '@onfido/castor-react';
 import React from 'react';
 import { withRef } from '../../utils';
-import { Input, InputProps } from '../input/input';
 
 /**
  * `Search` uses an `Icon` that requires `Icons` (SVG sprite) to be included in


### PR DESCRIPTION
## Purpose

Keep imports consistent.

## Approach

If import is exported via the package, import directly from it. Otherwise use relative path.

Only imports via relative paths are:
- internal components
- doc stuff
- in case it's a sibling file (e.g. if component has its own utilities)
- React utilities (not exported)

## Testing

Pipeline should be green, Storybook should function as expected.

## Risks

N/A
