### PR TITLE
build: check bundle size

### DIFF
--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -1,0 +1,17 @@
+{
+  "trackBranches": ["master"],
+  "files": [
+    {
+      "path": "./packages/core/dist/index.js",
+      "maxSize": "200B"
+    },
+    {
+      "path": "./packages/core/dist/castor.css",
+      "maxSize": "3kB"
+    },
+    {
+      "path": "./packages/react/dist/index.js",
+      "maxSize": "90B"
+    }
+  ]
+}

--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -1,5 +1,5 @@
 {
-  "trackBranches": ["master"],
+  "trackBranches": ["main"],
   "files": [
     {
       "path": "./packages/core/dist/index.js",

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Build packages
         run: yarn build
 
+      - name: Bundle size check
+        uses: jackyef/bundlewatch-gh-action@0.2.0
+        with:
+          bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+
       - name: Build (bundled) examples
         run: |
           yarn --cwd ./examples/custom-themes build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: jackyef/bundlewatch-gh-action@0.2.0
         with:
           bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
-          bundlewatch-config: ../../.bundlewatchrc.json
+          bundlewatch-config: .bundlewatchrc.json
 
       - name: Build (bundled) examples
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         uses: jackyef/bundlewatch-gh-action@0.2.0
         with:
           bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+          bundlewatch-config: ../../.bundlewatchrc.json
 
       - name: Build (bundled) examples
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      - name: Bundle size check
+      - name: Check bundle size
         uses: jackyef/bundlewatch-gh-action@0.2.0
         with:
           bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "files": [
       {
         "path": "./packages/core/dist/index.js",
-        "maxSize": "20B"
+        "maxSize": "200B"
       },
       {
         "path": "./packages/core/dist/castor.css",
@@ -101,7 +101,7 @@
       },
       {
         "path": "./packages/react/dist/index.js",
-        "maxSize": "9B"
+        "maxSize": "90B"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "bundlewatch": {
     "trackBranches": [
-      "master"
+      "main"
     ],
     "files": [
       {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "files": [
       {
         "path": "./packages/core/dist/index.js",
-        "maxSize": "200B"
+        "maxSize": "20B"
       },
       {
         "path": "./packages/core/dist/castor.css",
@@ -101,7 +101,7 @@
       },
       {
         "path": "./packages/react/dist/index.js",
-        "maxSize": "90B"
+        "maxSize": "9B"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "e2e:run": "wait-on http://localhost:6006 && cypress run -c video=true",
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
-    "release": "HUSKY=0 standard-version"
+    "release": "HUSKY=0 standard-version",
+    "check:bundle-size": "yarn build && yarn run bundlewatch"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
@@ -57,6 +58,7 @@
     "@types/theo": "^8.1.3",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
+    "bundlewatch": "^0.3.2",
     "commitizen": "^4.2.4",
     "concurrently": "^6.2.0",
     "cypress": "^7.4.0",
@@ -83,5 +85,24 @@
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4",
     "wait-on": "^5.3.0"
+  },
+  "bundlewatch": {
+    "trackBranches": [
+      "master"
+    ],
+    "files": [
+      {
+        "path": "./packages/core/dist/index.js",
+        "maxSize": "200B"
+      },
+      {
+        "path": "./packages/core/dist/castor.css",
+        "maxSize": "3kB"
+      },
+      {
+        "path": "./packages/react/dist/index.js",
+        "maxSize": "90B"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
     "release": "HUSKY=0 standard-version",
-    "check-bundle-size": "yarn build && yarn run bundlewatch --config ./.bundlewatchrc.json"
+    "check-bundle-size": "yarn build && yarn run bundlewatch --config .bundlewatchrc.json"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
     "release": "HUSKY=0 standard-version",
-    "check:bundle-size": "yarn build && yarn run bundlewatch"
+    "check-bundle-size": "yarn build && yarn run bundlewatch"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
     "release": "HUSKY=0 standard-version",
-    "check-bundle-size": "yarn build && yarn run bundlewatch --config .bundlewatchrc.json"
+    "check-bundle-size": "yarn build && yarn bundlewatch --config .bundlewatchrc.json"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
     "release": "HUSKY=0 standard-version",
-    "check-bundle-size": "yarn build && yarn run bundlewatch"
+    "check-bundle-size": "yarn build && yarn run bundlewatch --config ./.bundlewatchrc.json"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",
@@ -85,24 +85,5 @@
     "ts-jest": "^26.5.6",
     "typescript": "^4.2.4",
     "wait-on": "^5.3.0"
-  },
-  "bundlewatch": {
-    "trackBranches": [
-      "main"
-    ],
-    "files": [
-      {
-        "path": "./packages/core/dist/index.js",
-        "maxSize": "200B"
-      },
-      {
-        "path": "./packages/core/dist/castor.css",
-        "maxSize": "3kB"
-      },
-      {
-        "path": "./packages/react/dist/index.js",
-        "maxSize": "90B"
-      }
-    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4868,12 +4868,28 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
+bundlewatch@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/bundlewatch/-/bundlewatch-0.3.2.tgz#b07c57347a790f436f8b59c12418618f5e938432"
+  integrity sha512-gqekMv+ph1vKjM2B6P7mk8HxNZ3ZLOU94Vo3eFqPgQ0COqDsYcrPwsmpczAwsPxOMY7ZpKCGUez7shbdttCDew==
+  dependencies:
+    axios "^0.21.1"
+    bytes "^3.0.0"
+    chalk "^4.0.0"
+    ci-env "^1.14.0"
+    commander "^5.0.0"
+    glob "^7.1.2"
+    gzip-size "^5.1.1"
+    jsonpack "^1.1.5"
+    lodash.merge "^4.6.1"
+    read-pkg-up "^7.0.1"
+
 bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
 
-bytes@3.1.0:
+bytes@3.1.0, bytes@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
@@ -5217,6 +5233,11 @@ chrome-trace-event@^1.0.2:
   integrity sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==
   dependencies:
     tslib "^1.9.0"
+
+ci-env@^1.14.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/ci-env/-/ci-env-1.16.0.tgz#e97f3b5001a8daf7da6e46f418bc6892a238704d"
+  integrity sha512-ucF9caQEX5wQlY449KZBIJPx91+kRg9tJ3tWSc4+KzrvC5KNiPm/3g1noP8VhdI3046+Vw3jLmKAD0fjCRJTmw==
 
 ci-info@^2.0.0:
   version "2.0.0"
@@ -8731,7 +8752,7 @@ gulp-header@^1.7.1:
     lodash.template "^4.4.0"
     through2 "^2.0.0"
 
-gzip-size@5.1.1:
+gzip-size@5.1.1, gzip-size@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
   integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
@@ -10842,6 +10863,11 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonpack@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/jsonpack/-/jsonpack-1.1.5.tgz#d42b0dcfd91ac58ef3110f96d2c599404c3dc27c"
+  integrity sha1-1CsNz9kaxY7zEQ+W0sWZQEw9wnw=
+
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -11187,7 +11213,7 @@ lodash.memoize@~3.0.3:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-3.0.4.tgz#2dcbd2c287cbc0a55cc42328bd0c736150d53e3f"
   integrity sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=
 
-lodash.merge@^4.6.2:
+lodash.merge@^4.6.1, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
## Purpose

Add bundle size checking for #118 

## Approach

Add bundle size checking for castor/core and castor/react packages' build files using `bundlewatch`. This check is done as part of build Github Action workflow but can also be done locally by running `yarn check:bundle-size`.

## Testing

- Checked locally by tweaking `maxSize` in the `bundlewatch` config in `package.json` to deliberately trigger a failure when file size is above limit.
- PR build should also fail if this config's `maxSize` is changed to a value below the current sizes.

## Risks

N/A (might be worth defining what maximum file sizes to start with, current limit is set based on rounding up current sizes for each package's files)
