### PR TITLE
docs: add aria-hidden="true" to icons inside buttons

### DIFF
--- a/packages/core/src/components/button/button.stories.ts
+++ b/packages/core/src/components/button/button.stories.ts
@@ -42,7 +42,7 @@ export const AsAnchor: Story<ButtonProps> = (props) =>
   Button({ ...props, href: 'javascript:void 0' });
 
 const [firstIconName] = iconNames;
-const icon = Icon({ name: firstIconName });
+const icon = Icon({ name: firstIconName, ['aria-hidden']: 'true' });
 export const WithIcon: Story<ButtonProps> = (props: ButtonProps) =>
   Button({ ...props, children: icon + 'Button' }) +
   Button({ ...props, children: 'Button' + icon });

--- a/packages/core/src/components/icon/icon.story.tsx
+++ b/packages/core/src/components/icon/icon.story.tsx
@@ -1,13 +1,18 @@
-import { c, classy, color, IconProps } from '@onfido/castor';
+import { c, classy, color, IconProps as BaseProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
+
+export interface IconProps extends BaseProps {
+  'aria-hidden'?: 'true' | 'false';
+}
 
 /**
  * `.ods-icon` requires SVG sprite to be included in your app.
  *
  * https://github.com/onfido/castor-icons
  */
-export const Icon = ({ name, color: token }: IconProps) =>
+export const Icon = ({ name, color: token, ...props }: IconProps) =>
   html('svg', {
+    ...props,
     class: classy(c('icon')),
     fill: token ? color(token) : 'currentColor',
     focusable: 'false',

--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -60,12 +60,12 @@ export const WithIcon: Story<ButtonWithIconProps> = ({
 }: ButtonWithIconProps) => (
   <>
     <Button {...restProps}>
-      <Icon name={iconName} />
+      <Icon name={iconName} aria-hidden="true" />
       {children}
     </Button>
     <Button {...restProps}>
       {children}
-      <Icon name={iconName} />
+      <Icon name={iconName} aria-hidden="true" />
     </Button>
   </>
 );


### PR DESCRIPTION
## Purpose

For accessibility reasons icons inside buttons (that do have a button text) should have `aria-hidden="true"` set.

## Approach

In examples add `aria-hidden="true"`.

## Testing

On Storybook Core/React stories of Button with Icon.

## Risks

N/A
