### PR TITLE
docs: always connect label with input/textarea

### DIFF
--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -55,11 +55,13 @@ export const Disabled = htmlMatrix(Input, { disabled });
 Disabled.argTypes = omit<InputProps>('disabled');
 
 interface InputWithLabelAndHelperTextProps extends InputProps {
+  id: string;
   label: string;
   helperText: string;
 }
 
 export const WithLabelAndHelperText = ({
+  id,
   label,
   helperText,
   ...props
@@ -67,11 +69,17 @@ export const WithLabelAndHelperText = ({
   Field({
     children: [
       FieldLabel({
-        children: [label, HelperText({ children: helperText }), Input(props)],
+        children: [
+          label,
+          HelperText({ children: helperText }),
+          Input({ ...props, id }),
+        ],
+        for: id,
       }),
     ],
   });
 WithLabelAndHelperText.args = {
+  id: 'input-with-label-and-helper-text',
   label: 'Label',
   helperText: 'Helper text',
 };

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -60,11 +60,13 @@ export const Disabled = htmlMatrix(Textarea, { disabled });
 Disabled.argTypes = omit<TextareaProps>('disabled');
 
 interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
+  id: string;
   label: string;
   helperText: string;
 }
 
 export const WithLabelAndHelperText = ({
+  id,
   label,
   helperText,
   ...props
@@ -75,12 +77,14 @@ export const WithLabelAndHelperText = ({
         children: [
           label,
           HelperText({ children: helperText }),
-          Textarea(props),
+          Textarea({ ...props, id }),
         ],
+        for: id,
       }),
     ],
   });
 WithLabelAndHelperText.args = {
+  id: 'input-with-label-and-helper-text',
   label: 'Label',
   helperText: 'Helper text',
 };

--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -35,11 +35,11 @@ interface Values {
 export const Playground: Story<FormProps<Values>> = (props) => (
   <Form {...props}>
     <Field>
-      <FieldLabel>
+      <FieldLabel htmlFor="first-name">
         <span>
           First name <Asterisk aria-label="required" />
         </span>
-        <Input name="firstName" required />
+        <Input id="first-name" name="firstName" required />
       </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field
@@ -47,11 +47,11 @@ export const Playground: Story<FormProps<Values>> = (props) => (
     </Field>
 
     <Field>
-      <FieldLabel>
+      <FieldLabel htmlFor="last-name">
         <span>
           Last name <Asterisk aria-label="required" />
         </span>
-        <Input name="lastName" required />
+        <Input id="last-name" name="lastName" required />
       </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field
@@ -59,11 +59,11 @@ export const Playground: Story<FormProps<Values>> = (props) => (
     </Field>
 
     <Field>
-      <FieldLabel>
+      <FieldLabel htmlFor="email">
         <span>
           Email address <Asterisk aria-label="required" />
         </span>
-        <Input type="email" name="email" required />
+        <Input type="email" id="email" name="email" required />
       </FieldLabel>
       <Validation state="error" if="valueMissing">
         Please fill in this field

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -64,24 +64,27 @@ export const Disabled = reactMatrix(Input, { disabled });
 Disabled.argTypes = omit<InputProps>('disabled');
 
 interface InputWithLabelAndHelperTextProps extends InputProps {
+  id: string;
   label: string;
   helperText: string;
 }
 
 export const WithLabelAndHelperText = ({
+  id,
   label,
   helperText,
   ...restProps
 }: InputWithLabelAndHelperTextProps) => (
   <Field>
-    <FieldLabel>
+    <FieldLabel htmlFor={id}>
       {label}
       <HelperText>{helperText}</HelperText>
-      <Input {...restProps} />
+      <Input {...restProps} id={id} />
     </FieldLabel>
   </Field>
 );
 WithLabelAndHelperText.args = {
+  id: 'input-with-label-and-helper-text',
   label: 'Label',
   helperText: 'Helper text',
 };

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -72,24 +72,27 @@ export const Disabled = reactMatrix(Textarea, { disabled });
 Disabled.argTypes = omit<TextareaProps>('disabled');
 
 interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
+  id: string;
   label: string;
   helperText: string;
 }
 
 export const WithLabelAndHelperText = ({
+  id,
   label,
   helperText,
   ...restProps
 }: TextareaWithLabelAndHelperTextProps) => (
   <Field>
-    <FieldLabel>
+    <FieldLabel htmlFor={id}>
       {label}
       <HelperText>{helperText}</HelperText>
-      <Textarea {...restProps} />
+      <Textarea {...restProps} id={id} />
     </FieldLabel>
   </Field>
 );
 WithLabelAndHelperText.args = {
+  id: 'textarea-with-label-and-helper-text',
   label: 'Label',
   helperText: 'Helper text',
 };


### PR DESCRIPTION
## Purpose

Input and Textarea should always be connected to FieldLabel, even when it is nested - due to accessibility (screen readers).

## Approach

In Storybook stories connect Inputs and Textareas to FieldLabels.

## Testing

On Storybook, both Core and React stories of Input/Textarea with FieldLabel (and HelperText).

## Risks

N/A
