### PR TITLE
build: lint ts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Run ESLint
         run: yarn lint:es
 
+      - name: Run tsc (type check)
+        run: yarn lint:ts
+
       - name: Run Prettier
         run: yarn lint:prettier

--- a/docs/helpers/html.ts
+++ b/docs/helpers/html.ts
@@ -12,7 +12,7 @@ export const html = (
     `<${name}`,
     Object.entries(props).map(toAttribute).join('\n'),
     '>',
-    children?.join?.('\n') || children,
+    (children as unknown[])?.join?.('\n') || children,
     `</${name}>`,
   ]
     .filter(Boolean)

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "include": ["**/*"],
+  "exclude": [],
   "compilerOptions": {
     "noEmit": true,
     "sourceMap": false,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "lint": "concurrently yarn:lint:*",
     "lint:commit": "commitlint --from origin/main --to HEAD --verbose",
     "lint:es": "eslint . --ignore-path .gitignore --max-warnings 0",
+    "lint:ts": "tsc --noEmit",
     "lint:style": "stylelint '**/*.{,s}css' --ignore-path .gitignore --max-warnings 0",
     "lint:prettier": "prettier . --check --ignore-path .gitignore",
     "test": "jest --coverage",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "include": ["**/*"],
-  "exclude": ["node_modules/**/*"],
+  "exclude": ["node_modules/**/*", "e2e/**/*"],
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": false,


### PR DESCRIPTION
## Purpose

Catch TS (type) errors ahead of time, especially in our examples, docs, and test files.

Also make prettier ignore files it doesn't know, like `.hbs`.

## Approach

Run `tsc --noEmit` on lint.

## Testing

Should output some logs in our pipeline.
Run `tsc --noEmit` on `main` and some errors will be found, fixed in this branch.

## Risks

None.
