### PR TITLE
fix: correct "withIcon" validation prop type to be on core

### DIFF
--- a/packages/core/src/components/validation/validation.ts
+++ b/packages/core/src/components/validation/validation.ts
@@ -1,4 +1,5 @@
 export interface ValidationProps {
   if?: Exclude<keyof ValidityState, 'valid'> | 'invalid';
   state: 'error';
+  withIcon?: boolean;
 }

--- a/packages/react/src/components/validation/validation.tsx
+++ b/packages/react/src/components/validation/validation.tsx
@@ -40,7 +40,4 @@ export const Validation = ({
   );
 };
 
-export type ValidationProps = BaseProps &
-  JSX.IntrinsicElements['div'] & {
-    withIcon?: boolean;
-  };
+export type ValidationProps = BaseProps & JSX.IntrinsicElements['div'];


### PR DESCRIPTION
## Purpose

All component prop types that are to be reused across different frameworks (like also with Angular, Vue) should be set on a core package.

## Approach

Move Validation component prop type "withIcon" from React package to Core.

## Testing

N/A

## Risks

N/A
