### PR TITLE
docs(core): allow children in story to be null or undefined

### DIFF
--- a/packages/core/src/components/button/button.story.tsx
+++ b/packages/core/src/components/button/button.story.tsx
@@ -2,7 +2,7 @@ import { ButtonProps as BaseProps, c, classy, m } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface ButtonProps extends BaseProps {
-  children: string;
+  children?: string | null;
   href?: string;
 }
 

--- a/packages/core/src/components/field-label/field-label.story.tsx
+++ b/packages/core/src/components/field-label/field-label.story.tsx
@@ -2,7 +2,7 @@ import { c, classy } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface FieldLabelProps {
-  children: string | string[];
+  children?: string | string[] | null;
   for?: string;
 }
 

--- a/packages/core/src/components/field/field.story.tsx
+++ b/packages/core/src/components/field/field.story.tsx
@@ -2,7 +2,7 @@ import { c, classy } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface FieldProps {
-  children: string | string[];
+  children?: string | string[] | null;
 }
 
 /**

--- a/packages/core/src/components/helper-text/helper-text.story.tsx
+++ b/packages/core/src/components/helper-text/helper-text.story.tsx
@@ -2,7 +2,7 @@ import { c, classy, HelperTextProps as BaseProps, m } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface HelperTextProps extends BaseProps {
-  children: string | string[];
+  children?: string | string[] | null;
 }
 
 /**

--- a/packages/core/src/components/spinner/spinner.story.tsx
+++ b/packages/core/src/components/spinner/spinner.story.tsx
@@ -2,7 +2,7 @@ import { c, classy, m, SpinnerProps as BaseProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface SpinnerProps extends BaseProps {
-  children: string;
+  children?: string | null;
 }
 
 export const Spinner = ({ size, ...props }: SpinnerProps) =>

--- a/packages/core/src/components/textarea/textarea.story.tsx
+++ b/packages/core/src/components/textarea/textarea.story.tsx
@@ -2,7 +2,7 @@ import { c, classy, m, TextareaProps as BaseProps } from '@onfido/castor';
 import { html } from '../../../../../docs';
 
 export interface TextareaProps extends BaseProps {
-  children?: string;
+  children?: string | null;
   id?: string;
   rows?: number;
 }


### PR DESCRIPTION
## Purpose

When building core story for a component and "children" prop is in use, it's type should also accept `null` and `undefined`.

## Approach

Improve "children" prop type to also accept `null` and `undefined`, leaving `string` or `string[]` variation untouched.

## Testing

N/A

## Risks

N/A
