### PR TITLE
fix(react): hide icon within component using aria

### DIFF
--- a/packages/react/src/components/search/search.tsx
+++ b/packages/react/src/components/search/search.tsx
@@ -16,7 +16,7 @@ export const Search = withRef(
   ): JSX.Element => (
     <div className={classy(c('search'), className)} style={style}>
       <Input {...restProps} ref={ref} type="search" />
-      <Icon name="search" />
+      <Icon name="search" aria-hidden="true" />
     </div>
   )
 );

--- a/packages/react/src/components/validation/validation.tsx
+++ b/packages/react/src/components/validation/validation.tsx
@@ -34,7 +34,7 @@ export const Validation = ({
       {...restProps}
       className={classy(c('validation'), m(state), className)}
     >
-      {withIcon && <Icon name="error" />}
+      {withIcon && <Icon name="error" aria-hidden="true" />}
       {children}
     </div>
   );


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/703 icons used in other components should also be hidden from screen readers.

## Approach

Hide icons in Search and Validation (React) components using `aria-hidden="true"`.

## Testing

N/A

## Risks

N/A
