### PR TITLE
build: fix bundlewatch diff report

### DIFF
--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -1,17 +1,20 @@
 {
-  "trackBranches": ["main"],
+  "ci": {
+    "repoBranchBase": "main",
+    "trackBranches": ["main"]
+  },
   "files": [
     {
-      "path": "./packages/core/dist/index.js",
-      "maxSize": "200B"
+      "path": "./packages/*/dist/**/*.css",
+      "maxSize": "5kB"
     },
     {
-      "path": "./packages/core/dist/castor.css",
-      "maxSize": "3kB"
+      "path": "./packages/*/dist/**/*.js",
+      "maxSize": "1kB"
     },
     {
-      "path": "./packages/react/dist/index.js",
-      "maxSize": "90B"
+      "path": "./packages/*/prototype.js",
+      "maxSize": "20kB"
     }
   ]
 }

--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -5,12 +5,8 @@
   },
   "files": [
     {
-      "path": "./packages/*/dist/**/*.css",
+      "path": "./packages/core/dist/castor.css",
       "maxSize": "5kB"
-    },
-    {
-      "path": "./packages/*/dist/**/*.js",
-      "maxSize": "1kB"
     },
     {
       "path": "./packages/*/prototype.js",

--- a/.bundlewatchrc.json
+++ b/.bundlewatchrc.json
@@ -6,11 +6,11 @@
   "files": [
     {
       "path": "./packages/core/dist/castor.css",
-      "maxSize": "5kB"
+      "maxSize": "5KB"
     },
     {
       "path": "./packages/*/prototype.js",
-      "maxSize": "20kB"
+      "maxSize": "20KB"
     }
   ]
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,12 +25,6 @@ jobs:
       - name: Build packages
         run: yarn build
 
-      - name: Check bundle size
-        uses: jackyef/bundlewatch-gh-action@0.2.0
-        with:
-          bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
-          bundlewatch-config: .bundlewatchrc.json
-
       - name: Build (bundled) examples
         run: |
           yarn --cwd ./examples/custom-themes build
@@ -42,3 +36,9 @@ jobs:
 
       - name: Generate prototype
         run: yarn prototype
+
+      - name: Inspect bundle size
+        uses: jackyef/bundlewatch-gh-action@0.2.0
+        with:
+          bundlewatch-github-token: ${{ secrets.BUNDLEWATCH_GITHUB_TOKEN }}
+          bundlewatch-config: .bundlewatchrc.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,17 +38,21 @@ Then remove Node that was installed alongside Yarn:
 
     `yarn lint`
 
-3.  Commit according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). We support these tools:
+3.  Inspect built packages:
+
+    `yarn inspect`
+
+4.  Commit according to [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/). We support these tools:
 
     - Commitizen, which runs automatically on a pre-commit Git hook thanks to Husky.
 
     - The [VS Code plugin](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits).
 
-4.  When opening a pull request, provide as much details as possible for a reviewer to better understand the change.
+5.  When opening a pull request, provide as much details as possible for a reviewer to better understand the change.
 
-5.  Check the change manually locally _before_ you assign reviewers.
+6.  Check the change manually locally _before_ you assign reviewers.
 
-6.  When a PR is approved - **do not merge** until acceptance testing is done, and the change is ready for a release.
+7.  When a PR is approved - **do not merge** until acceptance testing is done, and the change is ready for a release.
 
 ### Run Storybook locally
 

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
     "e2e:run": "wait-on http://localhost:6006 && cypress run -c video=true",
     "e2e:serve": "NODE_ENV=e2e yarn start --ci --quiet",
     "snapshot": "CYPRESS_updateSnapshots=true yarn e2e",
-    "release": "HUSKY=0 standard-version",
-    "check-bundle-size": "yarn build && yarn bundlewatch --config .bundlewatchrc.json"
+    "inspect": "concurrently yarn:inspect:*",
+    "preinspect:bundle-size": "yarn build && yarn prototype",
+    "inspect:bundle-size": "bundlewatch --config .bundlewatchrc.json",
+    "release": "HUSKY=0 standard-version"
   },
   "devDependencies": {
     "@commitlint/cli": "^12.1.4",


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/699 fix bundle size diff.

## Approach

Tracking all `dist` JS and CSS files (of all packages) and prototypes, also setting `main` branch as base and the one to track.

In addition, setting max file sizes (subject to be reviewed), renaming script as "inspect".

## Testing

Report on PR.

## Risks

Not 100% sure diff will work, will need to be merged first in order to take effect.
