### PR TITLE
fix(react): do not set role as "button" on button as anchor

### DIFF
--- a/packages/core/src/components/button/button.story.tsx
+++ b/packages/core/src/components/button/button.story.tsx
@@ -11,5 +11,4 @@ export const Button = ({ href, kind, variant, ...props }: ButtonProps) =>
     ...props,
     class: classy(c('button'), m(`${kind}--${variant}`)),
     href,
-    role: href && 'button',
   });

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -18,14 +18,13 @@ export const Button: ButtonComponent = ({
         disabled, // will be overriden by props if set
       })}
       {...(restProps as HTMLAttributes<HTMLElement>)}
-      {...(Element === 'a' && { role: 'button' })}
       className={classy(c('button'), m(`${kind}--${variant}`), className)}
     />
   );
 };
 
 export type ButtonProps<T extends 'a' | 'button' = 'button'> = BaseProps &
-  (T extends 'a' ? Omit<AnchorElementProps, 'role'> : ButtonElementProps);
+  (T extends 'a' ? AnchorElementProps : ButtonElementProps);
 
 type ButtonComponent = {
   (props: BaseProps & AnchorElementProps): JSX.Element;


### PR DESCRIPTION
## Purpose

For accessibility, an anchor even if visually is looking like a button should not have a role of a "button" set, making it a button for screen readers.

## Approach

Remove auto-setting "button" as a role on Button component, when it's meant to be rendered as an anchor.

Also, adjusting core story (fix is for React only, for Core it's just a doc change).

## Testing

On Storybook, inspecting an element in DOM.

## Risks

N/A
