### PR TITLE
chore: dependabot ignore all later versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,13 +14,13 @@ updates:
     ignore:
       - dependency-name: 'autoprefixer'
         versions:
-          - 10.x
+          - '>= 10.0.0'
       - dependency-name: 'postcss-modules'
         versions:
-          - 4.x
+          - '>= 4.0.0'
       - dependency-name: 'sass-loader'
         versions:
-          - 11.x
+          - '>= 11.0.0'
       - dependency-name: 'webpack'
         versions:
-          - 5.x
+          - '>= 5.0.0'


### PR DESCRIPTION
## Purpose

Ignore certain dependencies from versions up.

## Approach

Instead of ignoring specific major release versions, release anything above the specified versions.

As specified [in Dependabot docs](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore).

## Testing

Once merged, a https://github.com/onfido/castor/pull/734 should be closed.

## Risks

N/A
