### PR TITLE
ci: setup node version based on .nvmrc file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,10 +12,14 @@ jobs:
         uses: actions/checkout@v2.3.4
       - run: git fetch origin main # needed for commitlint
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile
@@ -37,10 +41,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Cypress run
         uses: cypress-io/github-action@v2
@@ -62,10 +70,14 @@ jobs:
       - name: Checkout Git repository
         uses: actions/checkout@v2.3.4
 
-      - name: Setup Node
+      - name: Read .nvmrc
+        run: echo ::set-output name=NVMRC::$(cat .nvmrc)
+        id: nvm
+
+      - name: Setup Node (uses version from .nvmrc)
         uses: actions/setup-node@v2.1.5
         with:
-          node-version: 14
+          node-version: ${{ steps.nvm.outputs.NVMRC }}
 
       - name: Cypress run
         uses: cypress-io/github-action@v2


### PR DESCRIPTION
## Purpose

When upgrading Node version, we need to change it in multiple places. However, as we do use `.nvmrc` config, better to use such on CI also.

## Approach

On CI, read Node version required from `.nvmrc` file, then use that when setting up Node.

## Testing

On pipeline:

![Screenshot 2021-06-03 at 11 10 53](https://user-images.githubusercontent.com/20243687/120628285-6aa27880-c45c-11eb-83f5-c529173a2713.png)

## Risks

N/A
