### PR TITLE
docs(react): always connect label with select

### DIFF
--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -87,24 +87,27 @@ AsRequired.args = {
 };
 
 interface SelectWithLabelAndHelperTextProps extends SelectProps {
+  id: string;
   label: string;
   helperText: string;
 }
 
 export const WithLabelAndHelperText = ({
+  id,
   label,
   helperText,
   ...restProps
 }: SelectWithLabelAndHelperTextProps) => (
   <Field>
-    <FieldLabel>
+    <FieldLabel htmlFor={id}>
       {label}
       <HelperText>{helperText}</HelperText>
-      <Select {...restProps} />
+      <Select {...restProps} id={id} />
     </FieldLabel>
   </Field>
 );
 WithLabelAndHelperText.args = {
+  id: 'select-with-label-and-helper-text',
   label: 'Label',
   helperText: 'Helper text',
 };


### PR DESCRIPTION
## Purpose

Following https://github.com/onfido/castor/pull/704, Select should always be connected to FieldLabel, even when it is nested - due to accessibility (screen readers).

## Approach

In Storybook React story connect Select to FieldLabel.

## Testing

On Storybook, React story of Select with FieldLabel (and HelperText).

## Risks

N/A
