### PR TITLE
docs: place storybook components into subdirectory

### DIFF
--- a/packages/core/src/components/button/button.stories.ts
+++ b/packages/core/src/components/button/button.stories.ts
@@ -8,7 +8,7 @@ const kind = ['action', 'destructive'] as const;
 const variant = ['primary', 'secondary', 'tertiary'] as const;
 
 export default {
-  title: 'Core/Button',
+  title: 'Core/Components/Button',
   component: Button,
   argTypes: {
     disabled: {

--- a/packages/core/src/components/field-label/field-label.stories.ts
+++ b/packages/core/src/components/field-label/field-label.stories.ts
@@ -9,7 +9,7 @@ import { Textarea } from '../textarea/textarea.story';
 import { FieldLabel, FieldLabelProps } from './field-label.story';
 
 export default {
-  title: 'Core/FieldLabel',
+  title: 'Core/Components/Form/FieldLabel',
   component: FieldLabel,
   argTypes: omit<FieldLabelProps>('for'),
   args: {

--- a/packages/core/src/components/icon/icon.stories.ts
+++ b/packages/core/src/components/icon/icon.stories.ts
@@ -6,7 +6,7 @@ import { Icon } from './icon.story';
 const [firstIconName] = iconNames;
 
 export default {
-  title: 'Core/Icon',
+  title: 'Core/Components/Icon',
   component: Icon,
   argTypes: {
     color: {

--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -19,7 +19,7 @@ const type = [
 type.toString = () => type.map((value) => `"${value}"`).join('|');
 
 export default {
-  title: 'Core/Input',
+  title: 'Core/Components/Form/Input',
   component: Input,
   argTypes: {
     ...omit<InputProps>('id', 'value'),

--- a/packages/core/src/components/select/select.stories.ts
+++ b/packages/core/src/components/select/select.stories.ts
@@ -10,7 +10,7 @@ const disabled = [true, false] as const;
 const invalid = [true, false] as const;
 
 export default {
-  title: 'Core/Select',
+  title: 'Core/Components/Form/Select',
   component: Select,
   argTypes: {
     ...omit<SelectProps>('class', 'id', 'value'),

--- a/packages/core/src/components/spinner/spinner.stories.ts
+++ b/packages/core/src/components/spinner/spinner.stories.ts
@@ -4,7 +4,7 @@ import { Spinner, SpinnerProps } from './spinner.story';
 const size = ['large', 'medium', 'small'] as const;
 
 export default {
-  title: 'Core/Spinner',
+  title: 'Core/Components/Spinner',
   component: Spinner,
   argTypes: {
     children: {

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -16,7 +16,7 @@ const resize: readonly TextareaProps['resize'][] = [
 resize.toString = () => resize.map((value) => `"${value}"`).join('|');
 
 export default {
-  title: 'Core/Textarea',
+  title: 'Core/Components/Form/Textarea',
   component: Textarea,
   argTypes: {
     ...omit<TextareaProps>('id'),

--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -8,7 +8,7 @@ const kind = ['action', 'destructive'] as const;
 const variant = ['primary', 'secondary', 'tertiary'] as const;
 
 export default {
-  title: 'React/Button',
+  title: 'React/Components/Button',
   component: Button,
   argTypes: {
     disabled: {

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -15,7 +15,7 @@ const disabled = [true, false] as const;
 const invalid = [true, false] as const;
 
 export default {
-  title: 'React/Checkbox',
+  title: 'React/Components/Form/Checkbox',
   component: Checkbox,
   argTypes: {
     children: {

--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { Meta, omit, Story } from '../../../../../docs';
 
 export default {
-  title: 'React/FieldLabel',
+  title: 'React/Components/Form/FieldLabel',
   component: FieldLabel,
   args: {
     children: 'Label',

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { Meta, omit, Story } from '../../../../../docs';
 
 export default {
-  title: 'React/FieldsetLegend',
+  title: 'React/Components/Form/FieldsetLegend',
   component: FieldsetLegend,
   argTypes: {
     ...omit<FieldsetLegendProps>('className', 'style'),

--- a/packages/react/src/components/form/form.stories.tsx
+++ b/packages/react/src/components/form/form.stories.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { Meta, Story } from '../../../../../docs';
 
 export default {
-  title: 'React/Form',
+  title: 'React/Components/Form/Form',
   component: Form,
 } as Meta<FormProps<Values>>;
 

--- a/packages/react/src/components/icon/icon.stories.tsx
+++ b/packages/react/src/components/icon/icon.stories.tsx
@@ -6,7 +6,7 @@ import { colors, Meta, omit, reactMatrix, Story } from '../../../../../docs';
 const [firstIconName] = iconNames;
 
 export default {
-  title: 'React/Icon',
+  title: 'React/Components/Icon',
   component: Icon,
   argTypes: {
     color: {

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -24,7 +24,7 @@ const type = [
 type.toString = () => type.map((value) => `"${value}"`).join('|');
 
 export default {
-  title: 'React/Input',
+  title: 'React/Components/Form/Input',
   component: Input,
   argTypes: {
     disabled: {

--- a/packages/react/src/components/radio/radio.stories.tsx
+++ b/packages/react/src/components/radio/radio.stories.tsx
@@ -15,7 +15,7 @@ const disabled = [true, false] as const;
 const invalid = [true, false] as const;
 
 export default {
-  title: 'React/Radio',
+  title: 'React/Components/Form/Radio',
   component: Radio,
   argTypes: {
     children: {

--- a/packages/react/src/components/search/search.stories.tsx
+++ b/packages/react/src/components/search/search.stories.tsx
@@ -5,7 +5,7 @@ import { Meta, omit, reactMatrix, Story } from '../../../../../docs';
 const disabled = [true, false] as const;
 
 export default {
-  title: 'React/Search',
+  title: 'React/Components/Search',
   component: Search,
   argTypes: {
     disabled: {

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -15,7 +15,7 @@ const disabled = [true, false] as const;
 const invalid = [true, false] as const;
 
 export default {
-  title: 'React/Select',
+  title: 'React/Components/Form/Select',
   component: Select,
   argTypes: {
     children: {

--- a/packages/react/src/components/spinner/spinner.stories.tsx
+++ b/packages/react/src/components/spinner/spinner.stories.tsx
@@ -5,7 +5,7 @@ import { Meta, omit, reactMatrix, Story } from '../../../../../docs';
 const size = ['large', 'medium', 'small'] as const;
 
 export default {
-  title: 'React/Spinner',
+  title: 'React/Components/Spinner',
   component: Spinner,
   argTypes: {
     children: {

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -21,7 +21,7 @@ const resize: readonly TextareaProps['resize'][] = [
 resize.toString = () => resize.map((value) => `"${value}"`).join('|');
 
 export default {
-  title: 'React/Textarea',
+  title: 'React/Components/Form/Textarea',
   component: Textarea,
   argTypes: {
     disabled: {


### PR DESCRIPTION
## Purpose

To better manage increasing number of component stories, place them into subdirectories.

## Approach

Group component stories into "Components" subdirectory, the ones that interact with form - into "Form" subdirectory (nested).

## Testing

On Storybook preview.

## Risks

N/A
