### PR TITLE
ci: cache yarn

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
+      - name: Get Yarn cache directory path
+        run: echo ::set-output name=DIR::$(yarn cache dir)
+        id: yarn-cache
+
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,18 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
+      - name: Get Yarn cache directory path
+        run: echo ::set-output name=DIR::$(yarn cache dir)
+        id: yarn-cache
+
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,18 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
+      - name: Get Yarn cache directory path
+        run: echo ::set-output name=DIR::$(yarn cache dir)
+        id: yarn-cache
+
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,18 @@ jobs:
         with:
           node-version: ${{ steps.nvm.outputs.NVMRC }}
 
+      - name: Get Yarn cache directory path
+        run: echo ::set-output name=DIR::$(yarn cache dir)
+        id: yarn-cache
+
+      - name: Cache Yarn
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Install Node dependencies
         run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
## Purpose

Speed up CI jobs by caching Yarn.

## Approach

Follow Node's [Yarn approach](https://github.com/actions/cache/blob/main/examples.md#node---yarn) to caching, using action.

## Testing

N/A

## Risks

N/A
