### PR TITLE
docs: remove webpack constant build issue "fix" on storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -13,6 +13,7 @@ module.exports = {
     '@storybook/addon-controls',
     '@storybook/addon-a11y',
   ],
+  stories: ['../{docs,packages}/**/*.stories.ts{,x}'],
   webpackFinal: (config) => {
     config.module.rules.push({
       test: /\.scss$/,
@@ -41,8 +42,6 @@ module.exports = {
 
     return config;
   },
-  // https://github.com/storybookjs/storybook/issues/14342
-  stories: ['docs', 'packages'].map((f) => `../${f}/**/*.stories.ts{,x}`),
   // https://github.com/styleguidist/react-docgen-typescript/issues/356#issuecomment-857887751
   typescript: {
     reactDocgen: 'react-docgen',


### PR DESCRIPTION
## Purpose

There was [an issue with webpack and Storybook](https://github.com/storybookjs/storybook/issues/14342), that was causing a constant build when running in development mode.

It was "fixed" in https://github.com/onfido/castor/pull/554.

However, now with upcoming Storybook v6.3 [it will be fixed](https://github.com/storybookjs/storybook/issues/14342#issuecomment-852015506), and such is no longer needed.

## Approach

Remove the "fix".

## Testing

Only after Storybook v6.3 upgrade.

## Risks

N/A
