### PR TITLE
docs: remove "fix" for using react-docgen with typescript on storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -42,8 +42,4 @@ module.exports = {
 
     return config;
   },
-  // https://github.com/styleguidist/react-docgen-typescript/issues/356#issuecomment-857887751
-  typescript: {
-    reactDocgen: 'react-docgen',
-  },
 };


### PR DESCRIPTION
## Purpose

TypeScript could not be upgraded because of [issue with `react-docgen-typescript`](https://github.com/styleguidist/react-docgen-typescript/issues/356) (used on Storybook).

A [suggested "fix"](https://github.com/styleguidist/react-docgen-typescript/issues/356#issuecomment-857887751) [was applied](https://github.com/onfido/castor/commit/fa4158136cdb067a1895157dac1de4bc83867640) until issue resolved in v2 of `react-docgen-typescript`.

## Approach

Remove a "fix".

## Testing

Can only be tested once react-docgen-typescript v2 [is upgraded](https://github.com/hipstersmoothie/react-docgen-typescript-plugin/issues/43).

## Risks

N/A
