### PR TITLE
chore: don't run commitizen when commiting with message

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,10 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && yarn cz --hook || true
+# COMMIT_MSG_FILE=$1
+COMMIT_SOURCE=$2 # <none> (git commit) | message (git commit -m <msg>) | template | merge | squash | commit
+# SHA1=$3
+
+if [ "$COMMIT_SOURCE" = "" ]; then
+  exec < /dev/tty && yarn cz --hook || true
+fi


### PR DESCRIPTION
## Purpose

When commiting with a message (`git commit -m "<msg>"`), don't run Commitizen on Git hook.

## Approach

Check for [an input parameter](https://mincong.io/2019/07/23/prepare-commit-message-using-git-hook/#input-parameters) when running a hook, ignore if commit source is set.

## Testing

Tested locally.

## Risks

N/A
