### PR TITLE
fix(core): use css properties from csstype, do not rely on react

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,8 @@
     "!src/**/*.d.ts"
   ],
   "dependencies": {
-    "@onfido/castor-tokens": "^1.0.0-beta.4"
+    "@onfido/castor-tokens": "^1.0.0-beta.4",
+    "csstype": "^3.0.8"
   },
   "peerDependencies": {
     "@onfido/castor-icons": ">=1.0.0"

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -1,5 +1,5 @@
 import { toCSS } from '@onfido/castor';
-import { CSSProperties } from 'react';
+import { Properties } from 'csstype';
 
 /**
  * Returns an object that represents a `Font`.
@@ -40,7 +40,7 @@ export function font(name: FontName): Font {
 }
 
 export type Font = Pick<
-  CSSProperties,
+  Properties<string | number>,
   `font${'Family' | 'Size' | 'Weight'}` | 'lineHeight' | 'textTransform'
 >;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6301,6 +6301,11 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.7.tgz#2a5fb75e1015e84dd15692f71e89a1450290950b"
   integrity sha512-KxnUB0ZMlnUWCsx2Z8MUsr6qV6ja1w9ArPErJaJaF8a5SOWoHLIszeCTKGRGRgtLgYrs1E8CHkNSP1VZTTPc9g==
 
+csstype@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.8.tgz#d2266a792729fb227cd216fb572f43728e1ad340"
+  integrity sha512-jXKhWqXPmlUeoQnF/EhTtTl4C9SnrxSH/jZUih3jmO6lBKr99rP3/+FmrMj4EFpOXzMtXHAZkd3x0E6h6Fgflw==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"


### PR DESCRIPTION
## Purpose

Because a Font type within a helper uses CSSProperties that come from React dependency, a core package also requires React even for those who do not use it (but use TS).

## Approach

Instead of using CSSProperties that require to have React as a dependency even for a core package, depend directly on `csstype`.

Downside - introducing a dependency.

## Testing

Everything should still work as previously.

## Risks

N/A
