### PR TITLE
fix(core): font helper CSS-in-JS compatibility

### DIFF
--- a/packages/core/src/helpers/font/font.spec.ts
+++ b/packages/core/src/helpers/font/font.spec.ts
@@ -8,7 +8,6 @@ describe('font', () => {
     fontWeight: 'initial',
     lineHeight: 'initial',
     textTransform: 'none',
-    toString: expect.any(Function),
   };
 
   it('should allow selection by size only', () => {

--- a/packages/core/src/helpers/font/font.ts
+++ b/packages/core/src/helpers/font/font.ts
@@ -36,7 +36,10 @@ export function font(name: FontName): Font {
     ...(type && types[type as FontType]),
   } as Font;
 
-  return { ...styles, toString: () => toCSS(styles) } as Font;
+  // can't be enumerable otherwise it breaks CSS-in-JS
+  Object.defineProperty(styles, 'toString', { value: () => toCSS(styles) });
+
+  return styles;
 }
 
 export type Font = Pick<


### PR DESCRIPTION
## Purpose

Makes `toString` in the object that `font` helper returns non-enumerable so that CSS-in-JS tools won't try to apply it when using object notation, e.g.

```tsx
styled.div(font('300-regular'));
```

## Approach

Define the property in an non-enumerable way with `Object.defineProperty`.

## Testing

Unit tests' objects must match, and therefore no longer have `toString`.