### PR TITLE
feat(react): forwardRef all components

### DIFF
--- a/packages/react/src/components/asterisk/asterisk.tsx
+++ b/packages/react/src/components/asterisk/asterisk.tsx
@@ -1,16 +1,19 @@
 import { c, classy } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * Use in `FieldLabel` to denote required fields.
  */
-export const Asterisk = ({
-  className,
-  ...restProps
-}: AsteriskProps): JSX.Element => (
-  <abbr {...restProps} className={classy(c('asterisk'), className)}>
-    {' *'}
-  </abbr>
-);
+export const Asterisk = withRef(function Asterisk(
+  { className, ...restProps }: AsteriskProps,
+  ref?: AsteriskProps['ref']
+) {
+  return (
+    <abbr {...restProps} ref={ref} className={classy(c('asterisk'), className)}>
+      {' *'}
+    </abbr>
+  );
+});
 
 export type AsteriskProps = Omit<JSX.IntrinsicElements['abbr'], 'children'>;

--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -1,13 +1,17 @@
 import { ButtonProps as BaseProps, c, classy, m } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
 import React, { HTMLAttributes } from 'react';
+import { withRef } from '../../utils';
 
-export const Button: ButtonComponent = ({
-  kind = 'action',
-  variant = 'primary',
-  className,
-  ...restProps
-}: ButtonProps<'a'> | ButtonProps<'button'>) => {
+export const Button: ButtonComponent = withRef(function Button(
+  {
+    kind = 'action',
+    variant = 'primary',
+    className,
+    ...restProps
+  }: ButtonProps<'a'> | ButtonProps<'button'>,
+  ref?: AnchorRef | ButtonRef
+) {
   const { disabled } = useField();
 
   const Element = (restProps as ButtonProps<'a'>).href ? 'a' : 'button';
@@ -18,18 +22,21 @@ export const Button: ButtonComponent = ({
         disabled, // will be overriden by props if set
       })}
       {...(restProps as HTMLAttributes<HTMLElement>)}
+      ref={ref as never} // ignore bivariance, we know it's right
       className={classy(c('button'), m(`${kind}--${variant}`), className)}
     />
   );
-};
+});
 
 export type ButtonProps<T extends 'a' | 'button' = 'button'> = BaseProps &
   (T extends 'a' ? AnchorElementProps : ButtonElementProps);
 
 type ButtonComponent = {
-  (props: BaseProps & AnchorElementProps): JSX.Element;
-  (props: BaseProps & ButtonElementProps): JSX.Element;
+  (props: BaseProps & AnchorElementProps, ref?: AnchorRef): JSX.Element;
+  (props: BaseProps & ButtonElementProps, ref?: ButtonRef): JSX.Element;
 };
 
 type AnchorElementProps = JSX.IntrinsicElements['a'];
 type ButtonElementProps = JSX.IntrinsicElements['button'];
+type AnchorRef = AnchorElementProps['ref'];
+type ButtonRef = ButtonElementProps['ref'];

--- a/packages/react/src/components/checkbox/checkbox.tsx
+++ b/packages/react/src/components/checkbox/checkbox.tsx
@@ -6,48 +6,45 @@ import { withRef } from '../../utils';
 
 let count = 0;
 
-export const Checkbox = withRef(
-  (
-    {
-      id = `castor_checkbox_${++count}`,
-      bordered,
-      invalid,
-      children,
-      className,
-      style,
-      ...restProps
-    }: CheckboxProps,
-    ref: CheckboxProps['ref']
-  ): JSX.Element => {
-    const { disabled, touched } = useField();
-    const [containerProps, inputProps] = splitContainerProps(restProps);
+export const Checkbox = withRef(function Checkbox(
+  {
+    id = `castor_checkbox_${++count}`,
+    bordered,
+    invalid,
+    children,
+    className,
+    style,
+    ...restProps
+  }: CheckboxProps,
+  ref?: CheckboxProps['ref']
+) {
+  const { disabled, touched } = useField();
+  const [containerProps, inputProps] = splitContainerProps(restProps);
 
-    return (
-      <IndicatorContainer
-        {...containerProps}
-        htmlFor={id}
-        bordered={bordered}
-        className={className}
-        style={style}
-      >
-        {{
-          children,
-          input: (
-            <input
-              disabled={disabled} // will be overriden by props if set
-              {...inputProps}
-              ref={ref}
-              id={id}
-              type="checkbox"
-              className={classy(c('checkbox'), m({ invalid, touched }))}
-            />
-          ),
-        }}
-      </IndicatorContainer>
-    );
-  }
-);
-Checkbox.displayName = 'Checkbox';
+  return (
+    <IndicatorContainer
+      {...containerProps}
+      htmlFor={id}
+      bordered={bordered}
+      className={className}
+      style={style}
+    >
+      {{
+        children,
+        input: (
+          <input
+            disabled={disabled} // will be overriden by props if set
+            {...inputProps}
+            ref={ref}
+            id={id}
+            type="checkbox"
+            className={classy(c('checkbox'), m({ invalid, touched }))}
+          />
+        ),
+      }}
+    </IndicatorContainer>
+  );
+});
 
 export type CheckboxProps = BaseProps &
   Omit<JSX.IntrinsicElements['input'], 'type'>;

--- a/packages/react/src/components/field-label/field-label.tsx
+++ b/packages/react/src/components/field-label/field-label.tsx
@@ -1,5 +1,6 @@
 import { c, classy } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * Intended to be used within `Input` and `Textarea` components, providing a
@@ -8,11 +9,17 @@ import React from 'react';
  * Can also be used alongside these two components, but should then be connected
  * via the "htmlFor" prop.
  */
-export const FieldLabel = ({
-  className,
-  ...restProps
-}: FieldLabelProps): JSX.Element => (
-  <label {...restProps} className={classy(c('field-label'), className)} />
-);
+export const FieldLabel = withRef(function FieldLabel(
+  { className, ...restProps }: FieldLabelProps,
+  ref?: FieldLabelProps['ref']
+) {
+  return (
+    <label
+      {...restProps}
+      ref={ref}
+      className={classy(c('field-label'), className)}
+    />
+  );
+});
 
 export type FieldLabelProps = JSX.IntrinsicElements['label'];

--- a/packages/react/src/components/field/field.tsx
+++ b/packages/react/src/components/field/field.tsx
@@ -1,5 +1,6 @@
 import { c, classy, FieldProps as BaseProps, FieldState } from '@onfido/castor';
 import React, { SyntheticEvent, useState } from 'react';
+import { withRef } from '../../utils';
 import { FieldProvider } from './useField';
 
 export { useField } from './useField';
@@ -19,14 +20,17 @@ export { useField } from './useField';
  *   </Validation>
  * </Field>
  */
-export const Field = ({
-  disabled,
-  onBlur,
-  onChange,
-  onInvalid,
-  className,
-  ...restProps
-}: FieldProps): JSX.Element => {
+export const Field = withRef(function Field(
+  {
+    disabled,
+    onBlur,
+    onChange,
+    onInvalid,
+    className,
+    ...restProps
+  }: FieldProps,
+  ref?: FieldProps['ref']
+) {
   const [field, setField] = useState<FieldState>(initial);
 
   function initial(): FieldState {
@@ -42,6 +46,7 @@ export const Field = ({
       <div
         {...restProps}
         className={classy(c('field'), className)}
+        ref={ref}
         onBlur={(event) => {
           update({ touched: true, ...readInput(event) });
           onBlur?.(event);
@@ -57,7 +62,7 @@ export const Field = ({
       />
     </FieldProvider>
   );
-};
+});
 
 export type FieldProps = BaseProps & JSX.IntrinsicElements['div'];
 

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.tsx
@@ -1,14 +1,21 @@
 import { c, classy } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * Use within `Fieldset` component to provide a text legend.
  */
-export const FieldsetLegend = ({
-  className,
-  ...restProps
-}: FieldsetLegendProps): JSX.Element => (
-  <legend {...restProps} className={classy(c('fieldset-legend'), className)} />
-);
+export const FieldsetLegend = withRef(function FieldsetLegend(
+  { className, ...restProps }: FieldsetLegendProps,
+  ref?: FieldsetLegendProps['ref']
+) {
+  return (
+    <legend
+      {...restProps}
+      ref={ref}
+      className={classy(c('fieldset-legend'), className)}
+    />
+  );
+});
 
 export type FieldsetLegendProps = JSX.IntrinsicElements['legend'];

--- a/packages/react/src/components/fieldset/fieldset.tsx
+++ b/packages/react/src/components/fieldset/fieldset.tsx
@@ -1,20 +1,22 @@
 import { c, classy } from '@onfido/castor';
 import { useField } from '@onfido/castor-react';
 import React from 'react';
+import { withRef } from '../../utils';
 
-export const Fieldset = ({
-  className,
-  ...restProps
-}: FieldsetProps): JSX.Element => {
+export const Fieldset = withRef(function Fieldset(
+  { className, ...restProps }: FieldsetProps,
+  ref?: FieldsetProps['ref']
+) {
   const { disabled } = useField();
 
   return (
     <fieldset
       disabled={disabled} // will be overriden by props if set
       {...restProps}
+      ref={ref}
       className={classy(c('fieldset'), className)}
     />
   );
-};
+});
 
 export type FieldsetProps = JSX.IntrinsicElements['fieldset'];

--- a/packages/react/src/components/form/form.tsx
+++ b/packages/react/src/components/form/form.tsx
@@ -1,24 +1,29 @@
 import { c, classy, FormProps as BaseProps, m } from '@onfido/castor';
 import React, { FormEvent, useState } from 'react';
+import { withRef } from '../../utils';
 import { getFormValues } from './getFormValues';
 import { FormProvider } from './useForm';
 
 export { useForm } from './useForm';
 
-export const Form = <T extends Values>({
-  disabled,
-  onChange,
-  onInvalid,
-  onSubmit,
-  className,
-  ...restProps
-}: FormProps<T>) => {
+export const Form = withRef(function Form<T extends Values>(
+  {
+    disabled,
+    onChange,
+    onInvalid,
+    onSubmit,
+    className,
+    ...restProps
+  }: FormProps<T>,
+  ref?: FormProps<T>['ref']
+) {
   const [touched, setTouched] = useState<boolean>();
 
   return (
     <FormProvider value={{ disabled, touched }}>
       <form
         {...restProps}
+        ref={ref}
         className={classy(c('form'), m({ disabled }), className)}
         onChange={(event) =>
           onChange?.(event, getFormValues(event.currentTarget))
@@ -45,7 +50,7 @@ export const Form = <T extends Values>({
       />
     </FormProvider>
   );
-};
+});
 
 export interface FormProps<T extends Values>
   extends BaseProps,

--- a/packages/react/src/components/helper-text/helper-text.tsx
+++ b/packages/react/src/components/helper-text/helper-text.tsx
@@ -1,18 +1,21 @@
 import { c, classy, HelperTextProps as BaseProps, m } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * Intended to be used with field components, incl. `FieldLabel` itself.
  */
-export const HelperText = ({
-  disabled,
-  className,
-  ...restProps
-}: HelperTextProps): JSX.Element => (
-  <span
-    {...restProps}
-    className={classy(c('helper-text'), m({ disabled }), className)}
-  />
-);
+export const HelperText = withRef(function HelperText(
+  { disabled, className, ...restProps }: HelperTextProps,
+  ref?: HelperTextProps['ref']
+) {
+  return (
+    <span
+      {...restProps}
+      ref={ref}
+      className={classy(c('helper-text'), m({ disabled }), className)}
+    />
+  );
+});
 
 export type HelperTextProps = BaseProps & JSX.IntrinsicElements['span'];

--- a/packages/react/src/components/icon/icon.tsx
+++ b/packages/react/src/components/icon/icon.tsx
@@ -1,5 +1,6 @@
 import { c, classy, color, IconProps as BaseProps } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * `Icon` requires `Icons` (SVG sprite) to be included in your app. If you wish
@@ -8,20 +9,21 @@ import React from 'react';
  *
  * https://github.com/onfido/castor-icons
  */
-export const Icon = ({
-  name,
-  color: token,
-  className,
-  ...restProps
-}: IconProps): JSX.Element => (
-  <svg
-    {...restProps}
-    fill={token ? color(token) : 'currentColor'}
-    focusable="false"
-    className={classy(c('icon'), className)}
-  >
-    <use href={`#${name}`}></use>
-  </svg>
-);
+export const Icon = withRef(function Icon(
+  { name, color: token, className, ...restProps }: IconProps,
+  ref?: IconProps['ref']
+) {
+  return (
+    <svg
+      {...restProps}
+      ref={ref}
+      fill={token ? color(token) : 'currentColor'}
+      focusable="false"
+      className={classy(c('icon'), className)}
+    >
+      <use href={`#${name}`}></use>
+    </svg>
+  );
+});
 
 export type IconProps = BaseProps & JSX.IntrinsicElements['svg'];

--- a/packages/react/src/components/input/input.tsx
+++ b/packages/react/src/components/input/input.tsx
@@ -6,40 +6,37 @@ import { withRef } from '../../utils';
 
 let idCount = 0;
 
-export const Input = withRef(
-  (
-    {
-      id = `castor_input_${++idCount}`,
-      type = 'text',
-      invalid,
-      children,
-      className,
-      ...restProps
-    }: InputProps,
-    ref: InputProps['ref']
-  ): JSX.Element => {
-    const { disabled, touched } = useField();
+export const Input = withRef(function Input(
+  {
+    id = `castor_input_${++idCount}`,
+    type = 'text',
+    invalid,
+    children,
+    className,
+    ...restProps
+  }: InputProps,
+  ref?: InputProps['ref']
+) {
+  const { disabled, touched } = useField();
 
-    return (
-      <FieldLabelWrapper htmlFor={id}>
-        {{
-          children,
-          element: (
-            <input
-              disabled={disabled} // will be overriden by props if set
-              {...restProps}
-              ref={ref}
-              id={id}
-              type={type}
-              className={classy(c('input'), m({ invalid, touched }), className)}
-            />
-          ),
-        }}
-      </FieldLabelWrapper>
-    );
-  }
-);
-Input.displayName = 'Input';
+  return (
+    <FieldLabelWrapper htmlFor={id}>
+      {{
+        children,
+        element: (
+          <input
+            disabled={disabled} // will be overriden by props if set
+            {...restProps}
+            ref={ref}
+            id={id}
+            type={type}
+            className={classy(c('input'), m({ invalid, touched }), className)}
+          />
+        ),
+      }}
+    </FieldLabelWrapper>
+  );
+});
 
 export type InputProps = BaseProps &
   Omit<InputElementProps, 'children'> & {

--- a/packages/react/src/components/progress/progress.tsx
+++ b/packages/react/src/components/progress/progress.tsx
@@ -6,19 +6,23 @@ import {
   ProgressProps as BaseProps,
 } from '@onfido/castor';
 import React, { useMemo } from 'react';
+import { withRef } from '../../utils';
 
-export const Progress = ({
-  value,
-  min = 0,
-  max = 100,
-  size = 'regular',
-  hideLabel,
-  children,
-  style,
-  className,
-  'aria-valuetext': ariaValuetext,
-  ...restProps
-}: ProgressProps): JSX.Element => {
+export const Progress = withRef(function Progress(
+  {
+    value,
+    min = 0,
+    max = 100,
+    size = 'regular',
+    hideLabel,
+    children,
+    style,
+    className,
+    'aria-valuetext': ariaValuetext,
+    ...restProps
+  }: ProgressProps,
+  ref?: ProgressProps['ref']
+) {
   const percentValue = useMemo(
     () => `${Math.round(((value - min) * 100) / (max - min))}%`,
     [value, min, max]
@@ -27,6 +31,7 @@ export const Progress = ({
   return (
     <div
       {...restProps}
+      ref={ref}
       className={classy(c('progress'), m(size), className)}
       role="progressbar"
       aria-valuenow={value}
@@ -40,7 +45,7 @@ export const Progress = ({
       {!hideLabel && (children || percentValue)}
     </div>
   );
-};
+});
 
 export type ProgressProps = BaseProps &
   Omit<

--- a/packages/react/src/components/radio/radio.tsx
+++ b/packages/react/src/components/radio/radio.tsx
@@ -6,48 +6,45 @@ import { withRef } from '../../utils';
 
 let idCount = 0;
 
-export const Radio = withRef(
-  (
-    {
-      id = `castor_radio_${++idCount}`,
-      bordered,
-      invalid,
-      children,
-      className,
-      style,
-      ...restProps
-    }: RadioProps,
-    ref: RadioProps['ref']
-  ): JSX.Element => {
-    const { disabled, touched } = useField();
-    const [containerProps, inputProps] = splitContainerProps(restProps);
+export const Radio = withRef(function Radio(
+  {
+    id = `castor_radio_${++idCount}`,
+    bordered,
+    invalid,
+    children,
+    className,
+    style,
+    ...restProps
+  }: RadioProps,
+  ref?: RadioProps['ref']
+) {
+  const { disabled, touched } = useField();
+  const [containerProps, inputProps] = splitContainerProps(restProps);
 
-    return (
-      <IndicatorContainer
-        {...containerProps}
-        htmlFor={id}
-        bordered={bordered}
-        className={className}
-        style={style}
-      >
-        {{
-          children,
-          input: (
-            <input
-              disabled={disabled} // will be overriden by props if set
-              {...inputProps}
-              ref={ref}
-              id={id}
-              type="radio"
-              className={classy(c('radio'), m({ invalid, touched }))}
-            />
-          ),
-        }}
-      </IndicatorContainer>
-    );
-  }
-);
-Radio.displayName = 'Radio';
+  return (
+    <IndicatorContainer
+      {...containerProps}
+      htmlFor={id}
+      bordered={bordered}
+      className={className}
+      style={style}
+    >
+      {{
+        children,
+        input: (
+          <input
+            disabled={disabled} // will be overriden by props if set
+            {...inputProps}
+            ref={ref}
+            id={id}
+            type="radio"
+            className={classy(c('radio'), m({ invalid, touched }))}
+          />
+        ),
+      }}
+    </IndicatorContainer>
+  );
+});
 
 export type RadioProps = BaseProps &
   Omit<JSX.IntrinsicElements['input'], 'type'>;

--- a/packages/react/src/components/search/search.tsx
+++ b/packages/react/src/components/search/search.tsx
@@ -9,17 +9,16 @@ import { withRef } from '../../utils';
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Search = withRef(
-  (
-    { className, style, ...restProps }: SearchProps,
-    ref: SearchProps['ref']
-  ): JSX.Element => (
+export const Search = withRef(function Search(
+  { className, style, ...restProps }: SearchProps,
+  ref?: SearchProps['ref']
+) {
+  return (
     <div className={classy(c('search'), className)} style={style}>
       <Input {...restProps} ref={ref} type="search" />
       <Icon name="search" aria-hidden="true" />
     </div>
-  )
-);
-Search.displayName = 'Search';
+  );
+});
 
 export type SearchProps = Omit<InputProps, 'type' | 'invalid' | 'children'>;

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -11,49 +11,46 @@ let idCount = 0;
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Select = withRef(
-  (
-    {
-      id = `castor_select_${++idCount}`,
-      value,
-      borderless,
-      invalid,
-      children,
-      className,
-      onChange,
-      ...restProps
-    }: SelectProps,
-    ref: SelectProps['ref']
-  ): JSX.Element => {
-    const [empty, setEmpty] = useState(!value);
-    const { disabled, touched } = useField();
+export const Select = withRef(function Select(
+  {
+    id = `castor_select_${++idCount}`,
+    value,
+    borderless,
+    invalid,
+    children,
+    className,
+    onChange,
+    ...restProps
+  }: SelectProps,
+  ref?: SelectProps['ref']
+) {
+  const [empty, setEmpty] = useState(!value);
+  const { disabled, touched } = useField();
 
-    return (
-      <div className={classy(c('select'), m({ borderless }))}>
-        <select
-          disabled={disabled} // will be overriden by props if set
-          {...restProps}
-          ref={ref}
-          id={id}
-          value={value}
-          className={classy(
-            c('select-native'),
-            m({ empty, borderless, invalid, touched }),
-            className
-          )}
-          onChange={(ev) => {
-            setEmpty(value != null ? !value : !ev.currentTarget.value);
-            onChange?.(ev);
-          }}
-        >
-          {children}
-        </select>
-        <Icon name="chevron-down" />
-      </div>
-    );
-  }
-);
-Select.displayName = 'Select';
+  return (
+    <div className={classy(c('select'), m({ borderless }))}>
+      <select
+        disabled={disabled} // will be overriden by props if set
+        {...restProps}
+        ref={ref}
+        id={id}
+        value={value}
+        className={classy(
+          c('select-native'),
+          m({ empty, borderless, invalid, touched }),
+          className
+        )}
+        onChange={(ev) => {
+          setEmpty(value != null ? !value : !ev.currentTarget.value);
+          onChange?.(ev);
+        }}
+      >
+        {children}
+      </select>
+      <Icon name="chevron-down" />
+    </div>
+  );
+});
 
 export type SelectProps = BaseProps &
   JSX.IntrinsicElements['select'] & {

--- a/packages/react/src/components/spinner/spinner.tsx
+++ b/packages/react/src/components/spinner/spinner.tsx
@@ -1,15 +1,20 @@
 import { c, classy, m, SpinnerProps as BaseProps } from '@onfido/castor';
 import React from 'react';
+import { withRef } from '../../utils';
 
-export const Spinner = ({
-  size = 'medium',
-  children,
-  className,
-  ...restProps
-}: SpinnerProps): JSX.Element => (
-  <div {...restProps} className={classy(c('spinner'), m(size), className)}>
-    {children}
-  </div>
-);
+export const Spinner = withRef(function Spinner(
+  { size = 'medium', children, className, ...restProps }: SpinnerProps,
+  ref?: SpinnerProps['ref']
+) {
+  return (
+    <div
+      {...restProps}
+      ref={ref}
+      className={classy(c('spinner'), m(size), className)}
+    >
+      {children}
+    </div>
+  );
+});
 
 export type SpinnerProps = BaseProps & JSX.IntrinsicElements['div'];

--- a/packages/react/src/components/textarea/textarea.tsx
+++ b/packages/react/src/components/textarea/textarea.tsx
@@ -6,47 +6,44 @@ import { withRef } from '../../utils';
 
 let idCount = 0;
 
-export const Textarea = withRef(
-  (
-    {
-      id = `castor_textarea_${++idCount}`,
-      resize = 'vertical',
-      rows = 3,
-      invalid,
-      children,
-      className,
-      style,
-      ...restProps
-    }: TextareaProps,
-    ref: TextareaProps['ref']
-  ): JSX.Element => {
-    const { disabled, touched } = useField();
+export const Textarea = withRef(function Textarea(
+  {
+    id = `castor_textarea_${++idCount}`,
+    resize = 'vertical',
+    rows = 3,
+    invalid,
+    children,
+    className,
+    style,
+    ...restProps
+  }: TextareaProps,
+  ref?: TextareaProps['ref']
+) {
+  const { disabled, touched } = useField();
 
-    return (
-      <FieldLabelWrapper htmlFor={id}>
-        {{
-          children,
-          element: (
-            <textarea
-              disabled={disabled} // will be overriden by props if set
-              {...restProps}
-              ref={ref}
-              id={id}
-              rows={rows}
-              className={classy(
-                c('textarea'),
-                m({ invalid, touched }),
-                className
-              )}
-              style={{ ...style, resize }}
-            />
-          ),
-        }}
-      </FieldLabelWrapper>
-    );
-  }
-);
-Textarea.displayName = 'Textarea';
+  return (
+    <FieldLabelWrapper htmlFor={id}>
+      {{
+        children,
+        element: (
+          <textarea
+            disabled={disabled} // will be overriden by props if set
+            {...restProps}
+            ref={ref}
+            id={id}
+            rows={rows}
+            className={classy(
+              c('textarea'),
+              m({ invalid, touched }),
+              className
+            )}
+            style={{ ...style, resize }}
+          />
+        ),
+      }}
+    </FieldLabelWrapper>
+  );
+});
 
 export type TextareaProps = BaseProps &
   Omit<TextareaElementProps, 'children'> & {

--- a/packages/react/src/components/validation/validation.tsx
+++ b/packages/react/src/components/validation/validation.tsx
@@ -1,6 +1,7 @@
 import { c, classy, m, ValidationProps as BaseProps } from '@onfido/castor';
 import { Icon, useField } from '@onfido/castor-react';
 import React from 'react';
+import { withRef } from '../../utils';
 
 /**
  * Intended to be used alongside field components.
@@ -10,14 +11,17 @@ import React from 'react';
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Validation = ({
-  if: key,
-  state,
-  withIcon,
-  children,
-  className,
-  ...restProps
-}: ValidationProps): JSX.Element | null => {
+export const Validation = withRef(function Validation(
+  {
+    if: key,
+    state,
+    withIcon,
+    children,
+    className,
+    ...restProps
+  }: ValidationProps,
+  ref?: ValidationProps['ref']
+) {
   const { disabled, touched, validity } = useField();
 
   if (key)
@@ -32,12 +36,13 @@ export const Validation = ({
   return (
     <div
       {...restProps}
+      ref={ref}
       className={classy(c('validation'), m(state), className)}
     >
       {withIcon && <Icon name="error" aria-hidden="true" />}
       {children}
     </div>
   );
-};
+});
 
 export type ValidationProps = BaseProps & JSX.IntrinsicElements['div'];


### PR DESCRIPTION
## Purpose

Upcoming component Tooltip will be able to target any element, so we now have an use case for all components to expose their refs.

## Approach

Add `withRef` to all components.

## Testing

- Rendering each component with `ref={ref}` should work with no console logs/errors.
- Each component story's "view code" should still show the component with the correct name.

## Risks

None.
