### PR TITLE
refactor: migrate sass division

### DIFF
--- a/docs/decorators/container.scss
+++ b/docs/decorators/container.scss
@@ -19,10 +19,10 @@ $margin: castor.space(4);
   flex-flow: row wrap;
 
   // --- this is the same as gap, except Safari supports it
-  margin: $margin - $gap / 2;
+  margin: $margin - $gap * 0.5;
 
   > * {
-    margin: $gap / 2;
+    margin: $gap * 0.5;
   }
   // ---
 }

--- a/packages/core/src/components/checkbox/checkbox.scss
+++ b/packages/core/src/components/checkbox/checkbox.scss
@@ -30,7 +30,7 @@
 
       border: 0 solid helpers.color('content-on-action');
       border-width: 0 0 $stroke-size $stroke-size;
-      height: $width / 2;
+      height: $width * 0.5;
       transform: rotate(-45deg);
       transform-origin: 110% 20%; // rotates rectangle from dead center
       width: $width;
@@ -43,7 +43,7 @@
 
       background-color: helpers.color('content-on-action');
       height: $stroke-size;
-      margin: (($size - $stroke-size) / 2) (($size - $width) / 2);
+      margin: (($size - $stroke-size) * 0.5) (($size - $width) * 0.5);
       transform: none; // Firefox sets both [checked] and [indeterminate] states
       width: $width;
     }

--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -10,7 +10,7 @@
 @mixin _IndicatorContainer() {
   $input-size: helpers.space(2.75);
   $input-margin: 1px;
-  $padding: (helpers.space(6) - $input-size - $input-margin * 2) / 2;
+  $padding: (helpers.space(6) - $input-size - $input-margin * 2) * 0.5;
 
   .ods-input-label {
     @include helpers.font('300-regular');


### PR DESCRIPTION
## Purpose

Migrate Sass syntax since `/` for division is deprecated.

https://sass-lang.com/documentation/breaking-changes/slash-div

## Approach

`npx sass-migrator division **/*.scss`

