### PR TITLE
test: mount additional volumes during e2e testing

### DIFF
--- a/Dockerfile.cypress
+++ b/Dockerfile.cypress
@@ -2,12 +2,8 @@ FROM cypress/base:14
 
 WORKDIR /cypress
 
-COPY ./e2e ./e2e
 COPY ./packages ./packages
-COPY ./.nycrc.json .
-COPY ./cypress.json .
 COPY ./package.json .
 COPY ./yarn.lock .
-COPY ./tsconfig.json .
 
 RUN yarn install --frozen-lockfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,8 @@ services:
     volumes:
       - ./.nyc_output:/cypress/.nyc_output
       - ./coverage/e2e:/cypress/coverage/e2e
-      - ./e2e/.snapshots:/cypress/e2e/.snapshots
+      - ./e2e:/cypress/e2e
+      - ./packages:/cypress/packages
+      - ./.nycrc.json:/cypress/.nycrc.json
+      - ./cypress.json:/cypress/cypress.json
+      - ./tsconfig.json:/cypress/tsconfig.json


### PR DESCRIPTION
## Purpose

Docker image needs to be rebuilt each time a code (or config) is changed.

This is because files are copied over when building the image.

## Approach

Instead of copying everything during build, mount additional volumes that are then being synced.

`packages` still need to be copied over during build, because `yarn install` needs to do some actions within these directories.

## Testing

Tested locally, when modifying a file and running snapshot generation.

## Risks

N/A
