### PR TITLE
docs: omit popover class

### DIFF
--- a/packages/core/src/components/button/button.stories.ts
+++ b/packages/core/src/components/button/button.stories.ts
@@ -31,20 +31,20 @@ export default {
 export const Playground: Story<ButtonProps> = (props) => Button(props);
 
 export const Kind = htmlMatrix(Button, { kind });
-Kind.argTypes = omit<ButtonProps>('kind');
+Kind.argTypes = omit('kind');
 
 export const Variant = htmlMatrix(Button, { variant });
-Variant.argTypes = omit<ButtonProps>('variant');
+Variant.argTypes = omit('variant');
 
 export const Disabled = htmlMatrix(Button, { disabled });
-Disabled.argTypes = omit<ButtonProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 export const AsAnchor: Story<ButtonProps> = (props) =>
   Button({ ...props, href: 'javascript:void 0' });
 
 const [firstIconName] = iconNames;
 const icon = Icon({ name: firstIconName, ['aria-hidden']: 'true' });
-export const WithIcon: Story<ButtonProps> = (props: ButtonProps) =>
+export const WithIcon: Story<ButtonProps> = (props) =>
   Button({ ...props, children: icon + 'Button' }) +
   Button({ ...props, children: 'Button' + icon });
 

--- a/packages/core/src/components/field-label/field-label.stories.ts
+++ b/packages/core/src/components/field-label/field-label.stories.ts
@@ -11,7 +11,7 @@ import { FieldLabel, FieldLabelProps } from './field-label.story';
 export default {
   title: 'Core/FieldLabel',
   component: FieldLabel,
-  argTypes: omit<FieldLabelProps>('for'),
+  argTypes: omit('for'),
   args: {
     children: 'Label',
   },
@@ -55,7 +55,7 @@ export const WithHelperText: Story<FieldLabelWithHelperTextProps> = ({
     ...props,
     children: [label, HelperText({ children: helperText })],
   });
-WithHelperText.argTypes = omit<FieldLabelWithHelperTextProps>('children');
+WithHelperText.argTypes = omit('children');
 WithHelperText.args = {
   label: 'Label',
   helperText: 'Helper text',
@@ -66,7 +66,11 @@ interface FieldLabelWithInputProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithInput = ({ id, label, ...props }: FieldLabelWithInputProps) =>
+export const WithInput: Story<FieldLabelWithInputProps> = ({
+  id,
+  label,
+  ...props
+}) =>
   Field({
     children: [
       FieldLabel({
@@ -77,7 +81,7 @@ export const WithInput = ({ id, label, ...props }: FieldLabelWithInputProps) =>
       Input({ id }),
     ],
   });
-WithInput.argTypes = omit<FieldLabelWithInputProps>('children');
+WithInput.argTypes = omit('children');
 WithInput.args = {
   id: 'field-label-with-input',
   label: 'Label',
@@ -88,11 +92,11 @@ interface FieldLabelWithSelectProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithSelect = ({
+export const WithSelect: Story<FieldLabelWithSelectProps> = ({
   id,
   label,
   ...props
-}: FieldLabelWithSelectProps) =>
+}) =>
   Field({
     children: [
       FieldLabel({
@@ -111,7 +115,7 @@ export const WithSelect = ({
       }),
     ],
   });
-WithSelect.argTypes = omit<FieldLabelWithSelectProps>('children');
+WithSelect.argTypes = omit('children');
 WithSelect.args = {
   id: 'field-label-with-select',
   label: 'Label',
@@ -122,11 +126,11 @@ interface FieldLabelWithTextareaProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithTextarea = ({
+export const WithTextarea: Story<FieldLabelWithTextareaProps> = ({
   id,
   label,
   ...props
-}: FieldLabelWithTextareaProps) =>
+}) =>
   Field({
     children: [
       FieldLabel({
@@ -137,7 +141,7 @@ export const WithTextarea = ({
       Textarea({ id }),
     ],
   });
-WithTextarea.argTypes = omit<FieldLabelWithTextareaProps>('children');
+WithTextarea.argTypes = omit('children');
 WithTextarea.args = {
   id: 'field-label-with-textarea',
   label: 'Label',

--- a/packages/core/src/components/icon/icon.stories.ts
+++ b/packages/core/src/components/icon/icon.stories.ts
@@ -15,7 +15,7 @@ export default {
   title: 'Core/Icon',
   component: Icon,
   argTypes: {
-    ...omit<IconProps>('aria-hidden'),
+    ...omit('aria-hidden'),
     color: {
       control: { type: 'select', options: colors },
       table: {

--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -27,7 +27,7 @@ export default {
   title: 'Core/Input',
   component: Input,
   argTypes: {
-    ...omit<InputProps>('id', 'value'),
+    ...omit('id', 'value'),
     disabled: {
       table: { type: { summary: 'boolean' } },
     },
@@ -54,10 +54,10 @@ export default {
 export const Playground: Story<InputProps> = (props) => Input(props);
 
 export const Invalid = htmlMatrix(Input, { invalid });
-Invalid.argTypes = omit<InputProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = htmlMatrix(Input, { disabled });
-Disabled.argTypes = omit<InputProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 interface InputWithLabelAndHelperTextProps extends InputProps {
   id: string;
@@ -65,24 +65,20 @@ interface InputWithLabelAndHelperTextProps extends InputProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...props
-}: InputWithLabelAndHelperTextProps) =>
-  Field({
-    children: [
-      FieldLabel({
-        children: [
-          label,
-          HelperText({ children: helperText }),
-          Input({ ...props, id }),
-        ],
-        for: id,
-      }),
-    ],
-  });
+export const WithLabelAndHelperText: Story<InputWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...props }) =>
+    Field({
+      children: [
+        FieldLabel({
+          children: [
+            label,
+            HelperText({ children: helperText }),
+            Input({ ...props, id }),
+          ],
+          for: id,
+        }),
+      ],
+    });
 WithLabelAndHelperText.args = {
   id: 'input-with-label-and-helper-text',
   label: 'Label',

--- a/packages/core/src/components/popover/popover.stories.ts
+++ b/packages/core/src/components/popover/popover.stories.ts
@@ -2,6 +2,7 @@ import {
   html,
   htmlMatrix,
   Meta,
+  omit,
   optionsToSummary,
   Story,
 } from '../../../../../docs';
@@ -15,6 +16,7 @@ export default {
   title: 'Core/Popover',
   component: Popover,
   argTypes: {
+    ...omit('class'),
     align: {
       control: { type: 'inline-radio', options: align },
       defaultValue: 'center',

--- a/packages/core/src/components/progress/progress.stories.ts
+++ b/packages/core/src/components/progress/progress.stories.ts
@@ -15,7 +15,7 @@ export default {
   title: 'Core/Progress',
   component: Progress,
   argTypes: {
-    ...omit<ProgressProps>('aria-valuetext'),
+    ...omit('aria-valuetext'),
     children: {
       description: 'Optional label.',
     },
@@ -53,20 +53,20 @@ export default {
 export const Playground: Story<ProgressProps> = (props) => Progress(props);
 
 export const Size = htmlMatrix(Progress, { size });
-Size.argTypes = omit<ProgressProps>('size');
+Size.argTypes = omit('size');
 
 export const HideLabel = htmlMatrix(Progress, { hideLabel });
-HideLabel.argTypes = omit<ProgressProps>('hideLabel');
+HideLabel.argTypes = omit('hideLabel');
 
 export const WithCustomLabel: Story<ProgressProps> = (props) => Progress(props);
-WithCustomLabel.argTypes = omit<ProgressProps>('children', 'hideLabel');
+WithCustomLabel.argTypes = omit('children', 'hideLabel');
 WithCustomLabel.args = {
   children: 'Progress: 25%',
   hideLabel: false,
 };
 
 export const AllCombinations = htmlMatrix(Progress, { hideLabel, size });
-AllCombinations.argTypes = omit<ProgressProps>('hideLabel', 'size');
+AllCombinations.argTypes = omit('hideLabel', 'size');
 AllCombinations.parameters = {
   display: 'grid',
   columns: 'repeat(2, 1fr)',

--- a/packages/core/src/components/select/select.stories.ts
+++ b/packages/core/src/components/select/select.stories.ts
@@ -13,7 +13,7 @@ export default {
   title: 'Core/Select',
   component: Select,
   argTypes: {
-    ...omit<SelectProps>('class', 'id', 'required', 'value'),
+    ...omit('class', 'id', 'required', 'value'),
     children: {
       description: [
         'List of options using `<option>`.',
@@ -39,13 +39,13 @@ export default {
 export const Playground: Story<SelectProps> = (props) => Select(props);
 
 export const Borderless = htmlMatrix(Select, { borderless });
-Borderless.argTypes = omit<SelectProps>('borderless');
+Borderless.argTypes = omit('borderless');
 
 export const Invalid = htmlMatrix(Select, { invalid });
-Invalid.argTypes = omit<SelectProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = htmlMatrix(Select, { disabled });
-Disabled.argTypes = omit<SelectProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 export const AsRequired: Story<SelectProps> = (props) =>
   Select({ ...props, required: true });
@@ -80,24 +80,20 @@ interface SelectWithLabelAndHelperTextProps extends SelectProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...props
-}: SelectWithLabelAndHelperTextProps) =>
-  Field({
-    children: [
-      FieldLabel({
-        children: [
-          label,
-          HelperText({ children: helperText }),
-          Select({ ...props, id }),
-        ],
-        for: id,
-      }),
-    ],
-  });
+export const WithLabelAndHelperText: Story<SelectWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...props }) =>
+    Field({
+      children: [
+        FieldLabel({
+          children: [
+            label,
+            HelperText({ children: helperText }),
+            Select({ ...props, id }),
+          ],
+          for: id,
+        }),
+      ],
+    });
 WithLabelAndHelperText.args = {
   id: 'select-with-label-and-helper-text',
   label: 'Label',
@@ -109,7 +105,7 @@ export const AllCombinations = htmlMatrix(
   { borderless, disabled, invalid },
   (props) => Select({ ...props, children: children(props) })
 );
-AllCombinations.argTypes = omit<SelectProps>('children');
+AllCombinations.argTypes = omit('children');
 AllCombinations.args = {
   children: null,
 };

--- a/packages/core/src/components/spinner/spinner.stories.ts
+++ b/packages/core/src/components/spinner/spinner.stories.ts
@@ -31,10 +31,10 @@ export default {
 export const Playground: Story<SpinnerProps> = (props) => Spinner(props);
 
 export const Size = htmlMatrix(Spinner, { size });
-Size.argTypes = omit<SpinnerProps>('size');
+Size.argTypes = omit('size');
 
 export const WithoutLabel: Story<SpinnerProps> = (props) => Spinner(props);
-WithoutLabel.argTypes = omit<SpinnerProps>('children');
+WithoutLabel.argTypes = omit('children');
 WithoutLabel.args = {
   children: null,
 };

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -12,19 +12,13 @@ import { Textarea, TextareaProps } from './textarea.story';
 
 const disabled = [true, false] as const;
 const invalid = [true, false] as const;
-
-const resize: readonly TextareaProps['resize'][] = [
-  'vertical',
-  'horizontal',
-  'both',
-  'none',
-];
+const resize = ['vertical', 'horizontal', 'both', 'none'] as const;
 
 export default {
   title: 'Core/Textarea',
   component: Textarea,
   argTypes: {
-    ...omit<TextareaProps>('id'),
+    ...omit('id'),
     disabled: {
       table: { type: { summary: 'boolean' } },
     },
@@ -56,13 +50,13 @@ export default {
 export const Playground: Story<TextareaProps> = (props) => Textarea(props);
 
 export const Resize = htmlMatrix(Textarea, { resize });
-Resize.argTypes = omit<TextareaProps>('resize');
+Resize.argTypes = omit('resize');
 
 export const Invalid = htmlMatrix(Textarea, { invalid });
-Invalid.argTypes = omit<TextareaProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = htmlMatrix(Textarea, { disabled });
-Disabled.argTypes = omit<TextareaProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
   id: string;
@@ -70,24 +64,20 @@ interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...props
-}: TextareaWithLabelAndHelperTextProps) =>
-  Field({
-    children: [
-      FieldLabel({
-        children: [
-          label,
-          HelperText({ children: helperText }),
-          Textarea({ ...props, id }),
-        ],
-        for: id,
-      }),
-    ],
-  });
+export const WithLabelAndHelperText: Story<TextareaWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...props }) =>
+    Field({
+      children: [
+        FieldLabel({
+          children: [
+            label,
+            HelperText({ children: helperText }),
+            Textarea({ ...props, id }),
+          ],
+          for: id,
+        }),
+      ],
+    });
 WithLabelAndHelperText.args = {
   id: 'input-with-label-and-helper-text',
   label: 'Label',

--- a/packages/react/src/components/button/button.stories.tsx
+++ b/packages/react/src/components/button/button.stories.tsx
@@ -41,18 +41,18 @@ export const Playground: Story<ButtonProps<'a'>> = (props) => (
 );
 
 export const Kind = reactMatrix(Button, { kind });
-Kind.argTypes = omit<ButtonProps>('kind');
+Kind.argTypes = omit('kind');
 
 export const Variant = reactMatrix(Button, { variant });
-Variant.argTypes = omit<ButtonProps>('variant');
+Variant.argTypes = omit('variant');
 
 export const Disabled = reactMatrix(Button, { disabled });
-Disabled.argTypes = omit<ButtonProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 export const AsAnchor: Story<ButtonProps<'a'>> = (props) => (
   <Button href="javascript:void 0" {...props} />
 );
-AsAnchor.argTypes = omit<ButtonProps<'a'>>('href');
+AsAnchor.argTypes = omit('href');
 
 const [firstIconName] = iconNames;
 
@@ -64,7 +64,7 @@ export const WithIcon: Story<ButtonWithIconProps> = ({
   iconName,
   children,
   ...restProps
-}: ButtonWithIconProps) => (
+}) => (
   <>
     <Button {...restProps}>
       <Icon name={iconName} aria-hidden="true" />

--- a/packages/react/src/components/checkbox/checkbox.stories.tsx
+++ b/packages/react/src/components/checkbox/checkbox.stories.tsx
@@ -7,7 +7,7 @@ import {
   HelperText,
   Validation,
 } from '@onfido/castor-react';
-import React, { ChangeEvent, useRef } from 'react';
+import React from 'react';
 import { Meta, omit, reactMatrix, Story } from '../../../../../docs';
 
 const bordered = [true, false] as const;
@@ -40,40 +40,37 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<CheckboxProps>;
 
-export const Playground: Story<CheckboxProps> = (props: CheckboxProps) => (
+export const Playground: Story<CheckboxProps> = (props) => (
   <Checkbox {...props} />
 );
 
 export const Bordered = reactMatrix(Checkbox, { bordered });
-Bordered.argTypes = omit<CheckboxProps>('bordered');
+Bordered.argTypes = omit('bordered');
 
 export const Invalid = reactMatrix(Checkbox, { invalid });
-Invalid.argTypes = omit<CheckboxProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = reactMatrix(Checkbox, { disabled });
-Disabled.argTypes = omit<CheckboxProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
-export const AsIndeterminate = (props: CheckboxProps) => {
-  const checkboxRef = useRef<HTMLInputElement | null>(null);
-
-  const handleChange = ({
-    target: { checked: indeterminate },
-  }: ChangeEvent<HTMLInputElement>) => {
-    if (checkboxRef.current) checkboxRef.current.indeterminate = indeterminate;
-  };
-
-  return <Checkbox {...props} ref={checkboxRef} onChange={handleChange} />;
-};
+export const AsIndeterminate: Story<CheckboxProps> = (props) => (
+  <Checkbox
+    {...props}
+    onChange={(ev) =>
+      (ev.currentTarget.indeterminate = ev.currentTarget.checked)
+    }
+  />
+);
 
 interface CheckboxesWithFieldsetLegendProps extends CheckboxProps {
   name: string;
   legend: string;
 }
 
-export const WithFieldsetLegend = ({
+export const WithFieldsetLegend: Story<CheckboxesWithFieldsetLegendProps> = ({
   legend,
   ...restProps
-}: CheckboxesWithFieldsetLegendProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend>{legend}</FieldsetLegend>
     <Field>
@@ -88,8 +85,7 @@ export const WithFieldsetLegend = ({
     </Field>
   </Fieldset>
 );
-WithFieldsetLegend.argTypes =
-  omit<CheckboxesWithFieldsetLegendProps>('children');
+WithFieldsetLegend.argTypes = omit('children');
 WithFieldsetLegend.args = {
   name: 'checkboxes-with-fieldset-legend',
   legend: 'Legend',
@@ -100,11 +96,11 @@ interface CheckboxWithHelperTextProps extends CheckboxProps {
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithHelperText: Story<CheckboxWithHelperTextProps> = ({
   label,
   helperText,
   ...restProps
-}: CheckboxWithHelperTextProps) => (
+}) => (
   <Field>
     <Checkbox {...restProps}>
       {label}
@@ -112,7 +108,7 @@ export const WithHelperText = ({
     </Checkbox>
   </Field>
 );
-WithHelperText.argTypes = omit<CheckboxWithHelperTextProps>('children');
+WithHelperText.argTypes = omit('children');
 WithHelperText.args = {
   label: 'Label',
   helperText: 'Helper text',
@@ -124,11 +120,11 @@ interface CheckboxWithValidationProps extends CheckboxProps {
   withIcon: boolean;
 }
 
-export const WithValidation = ({
+export const WithValidation: Story<CheckboxWithValidationProps> = ({
   validation,
   withIcon,
   ...restProps
-}: CheckboxWithValidationProps) => (
+}) => (
   <Field>
     <Checkbox {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
@@ -136,10 +132,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<CheckboxWithValidationProps>(
-  'invalid',
-  'disabled'
-);
+WithValidation.argTypes = omit('disabled', 'invalid');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,

--- a/packages/react/src/components/field-label/field-label.stories.tsx
+++ b/packages/react/src/components/field-label/field-label.stories.tsx
@@ -20,14 +20,14 @@ export default {
   },
 } as Meta<FieldLabelProps>;
 
-export const Playground: Story<FieldLabelProps> = (props: FieldLabelProps) => (
+export const Playground: Story<FieldLabelProps> = (props) => (
   <FieldLabel {...props} />
 );
 
 export const AsOptional: Story<FieldLabelProps> = ({
   children,
   ...restProps
-}: FieldLabelProps) => (
+}) => (
   <FieldLabel {...restProps}>
     <span>
       {children}{' '}
@@ -39,7 +39,7 @@ export const AsOptional: Story<FieldLabelProps> = ({
 export const AsRequired: Story<FieldLabelProps> = ({
   children,
   ...restProps
-}: FieldLabelProps) => (
+}) => (
   <FieldLabel {...restProps}>
     <span>
       {children}
@@ -53,17 +53,17 @@ interface FieldLabelWithHelperTextProps extends FieldLabelProps {
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithHelperText: Story<FieldLabelWithHelperTextProps> = ({
   label,
   helperText,
   ...restProps
-}: FieldLabelWithHelperTextProps) => (
+}) => (
   <FieldLabel {...restProps}>
     {label}
     <HelperText>{helperText}</HelperText>
   </FieldLabel>
 );
-WithHelperText.argTypes = omit<FieldLabelWithHelperTextProps>('children');
+WithHelperText.argTypes = omit('children');
 WithHelperText.args = {
   label: 'Label',
   helperText: 'Helper text',
@@ -74,11 +74,11 @@ interface FieldLabelWithInputProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithInput = ({
+export const WithInput: Story<FieldLabelWithInputProps> = ({
   id,
   label,
   ...restProps
-}: FieldLabelWithInputProps) => (
+}) => (
   <Field>
     <FieldLabel {...restProps} htmlFor={id}>
       {label}
@@ -86,7 +86,7 @@ export const WithInput = ({
     <Input id={id} />
   </Field>
 );
-WithInput.argTypes = omit<FieldLabelWithInputProps>('children');
+WithInput.argTypes = omit('children');
 WithInput.args = {
   id: 'field-label-with-input',
   label: 'Label',
@@ -97,11 +97,11 @@ interface FieldLabelWithSelectProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithSelect = ({
+export const WithSelect: Story<FieldLabelWithSelectProps> = ({
   id,
   label,
   ...restProps
-}: FieldLabelWithSelectProps) => (
+}) => (
   <Field>
     <FieldLabel {...restProps} htmlFor={id}>
       {label}
@@ -114,7 +114,7 @@ export const WithSelect = ({
     </Select>
   </Field>
 );
-WithSelect.argTypes = omit<FieldLabelWithSelectProps>('children');
+WithSelect.argTypes = omit('children');
 WithSelect.args = {
   id: 'field-label-with-select',
   label: 'Label',
@@ -125,11 +125,11 @@ interface FieldLabelWithTextareaProps extends FieldLabelProps {
   label: string;
 }
 
-export const WithTextarea = ({
+export const WithTextarea: Story<FieldLabelWithTextareaProps> = ({
   id,
   label,
   ...restProps
-}: FieldLabelWithTextareaProps) => (
+}) => (
   <Field>
     <FieldLabel {...restProps} htmlFor={id}>
       {label}
@@ -137,7 +137,7 @@ export const WithTextarea = ({
     <Textarea id={id} />
   </Field>
 );
-WithTextarea.argTypes = omit<FieldLabelWithTextareaProps>('children');
+WithTextarea.argTypes = omit('children');
 WithTextarea.args = {
   id: 'field-label-with-textarea',
   label: 'Label',

--- a/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
+++ b/packages/react/src/components/fieldset-legend/fieldset-legend.stories.tsx
@@ -15,7 +15,7 @@ export default {
   title: 'React/FieldsetLegend',
   component: FieldsetLegend,
   argTypes: {
-    ...omit<FieldsetLegendProps>('className', 'style'),
+    ...omit('className', 'style'),
     children: { control: 'text' },
   },
   args: {
@@ -23,9 +23,7 @@ export default {
   },
 } as Meta<FieldsetLegendProps>;
 
-export const Playground: Story<FieldsetLegendProps> = (
-  props: FieldsetLegendProps
-) => (
+export const Playground: Story<FieldsetLegendProps> = (props) => (
   <Fieldset>
     <FieldsetLegend {...props} />
   </Fieldset>
@@ -34,7 +32,7 @@ export const Playground: Story<FieldsetLegendProps> = (
 export const AsOptional: Story<FieldsetLegendProps> = ({
   children,
   ...restProps
-}: FieldsetLegendProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend {...restProps}>
       <span>
@@ -48,7 +46,7 @@ export const AsOptional: Story<FieldsetLegendProps> = ({
 export const AsRequired: Story<FieldsetLegendProps> = ({
   children,
   ...restProps
-}: FieldsetLegendProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend {...restProps}>
       <span>
@@ -64,11 +62,11 @@ interface FieldsetLegendWithHelperTextProps extends FieldsetLegendProps {
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithHelperText: Story<FieldsetLegendWithHelperTextProps> = ({
   legend,
   helperText,
   ...restFieldsetLegendProps
-}: FieldsetLegendWithHelperTextProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend {...restFieldsetLegendProps}>
       {legend}
@@ -76,7 +74,7 @@ export const WithHelperText = ({
     </FieldsetLegend>
   </Fieldset>
 );
-WithHelperText.argTypes = omit<FieldsetLegendWithHelperTextProps>('children');
+WithHelperText.argTypes = omit('children');
 WithHelperText.args = {
   legend: 'Legend',
   helperText: 'Helper text',
@@ -87,11 +85,11 @@ interface FieldsetLegendWithCheckboxesProps extends FieldsetLegendProps {
   legend: string;
 }
 
-export const WithCheckboxes = ({
+export const WithCheckboxes: Story<FieldsetLegendWithCheckboxesProps> = ({
   name,
   legend,
   ...restFieldsetLegendProps
-}: FieldsetLegendWithCheckboxesProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend {...restFieldsetLegendProps}>{legend}</FieldsetLegend>
     <Checkbox name={name} value="1">
@@ -102,7 +100,7 @@ export const WithCheckboxes = ({
     </Checkbox>
   </Fieldset>
 );
-WithCheckboxes.argTypes = omit<FieldsetLegendWithCheckboxesProps>('children');
+WithCheckboxes.argTypes = omit('children');
 WithCheckboxes.args = {
   name: 'fieldset-legend-with-checkboxes',
   legend: 'Legend',
@@ -113,11 +111,11 @@ interface FieldsetLegendWithRadiosProps extends FieldsetLegendProps {
   legend: string;
 }
 
-export const WithRadios = ({
+export const WithRadios: Story<FieldsetLegendWithRadiosProps> = ({
   name,
   legend,
   ...restFieldsetLegendProps
-}: FieldsetLegendWithRadiosProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend {...restFieldsetLegendProps}>{legend}</FieldsetLegend>
     <Radio name={name} value="yes">
@@ -128,7 +126,7 @@ export const WithRadios = ({
     </Radio>
   </Fieldset>
 );
-WithRadios.argTypes = omit<FieldsetLegendWithRadiosProps>('children');
+WithRadios.argTypes = omit('children');
 WithRadios.args = {
   name: 'fieldset-legend-with-radios',
   legend: 'Legend',

--- a/packages/react/src/components/icon/icon.stories.tsx
+++ b/packages/react/src/components/icon/icon.stories.tsx
@@ -43,7 +43,7 @@ export const Name = reactMatrix(Icon, { name: iconNames }, (props) => (
     <Icon {...props} /> {props.name}
   </>
 ));
-Name.argTypes = omit<IconProps>('name');
+Name.argTypes = omit('name');
 Name.parameters = {
   display: 'grid',
   columns: 'repeat(4, auto 1fr)',

--- a/packages/react/src/components/input/input.stories.tsx
+++ b/packages/react/src/components/input/input.stories.tsx
@@ -58,15 +58,13 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<InputProps>;
 
-export const Playground: Story<InputProps> = (props: InputProps) => (
-  <Input {...props} />
-);
+export const Playground: Story<InputProps> = (props) => <Input {...props} />;
 
 export const Invalid = reactMatrix(Input, { invalid });
-Invalid.argTypes = omit<InputProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = reactMatrix(Input, { disabled });
-Disabled.argTypes = omit<InputProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 interface InputWithLabelAndHelperTextProps extends InputProps {
   id: string;
@@ -74,20 +72,16 @@ interface InputWithLabelAndHelperTextProps extends InputProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...restProps
-}: InputWithLabelAndHelperTextProps) => (
-  <Field>
-    <FieldLabel htmlFor={id}>
-      {label}
-      <HelperText>{helperText}</HelperText>
-      <Input {...restProps} id={id} />
-    </FieldLabel>
-  </Field>
-);
+export const WithLabelAndHelperText: Story<InputWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...restProps }) => (
+    <Field>
+      <FieldLabel htmlFor={id}>
+        {label}
+        <HelperText>{helperText}</HelperText>
+        <Input {...restProps} id={id} />
+      </FieldLabel>
+    </Field>
+  );
 WithLabelAndHelperText.args = {
   id: 'input-with-label-and-helper-text',
   label: 'Label',
@@ -99,11 +93,11 @@ interface InputWithValidationProps extends InputProps {
   withIcon: boolean;
 }
 
-export const WithValidation = ({
+export const WithValidation: Story<InputWithValidationProps> = ({
   validation,
   withIcon,
   ...restProps
-}: InputWithValidationProps) => (
+}) => (
   <Field>
     <Input {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
@@ -111,7 +105,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<InputWithValidationProps>('invalid', 'disabled');
+WithValidation.argTypes = omit('disabled', 'invalid');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,

--- a/packages/react/src/components/popover/popover.stories.tsx
+++ b/packages/react/src/components/popover/popover.stories.tsx
@@ -16,7 +16,7 @@ export default {
   title: 'React/Popover',
   component: Popover,
   argTypes: {
-    ...omit<PopoverProps>('onClose', 'target'),
+    ...omit('onClose', 'target'),
     align: {
       control: { type: 'inline-radio', options: align },
       table: {

--- a/packages/react/src/components/progress/progress.stories.tsx
+++ b/packages/react/src/components/progress/progress.stories.tsx
@@ -60,26 +60,26 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<ProgressProps>;
 
-export const Playground: Story<ProgressProps> = (props: ProgressProps) => (
+export const Playground: Story<ProgressProps> = (props) => (
   <Progress {...props} />
 );
 
 export const Size = reactMatrix(Progress, { size });
-Size.argTypes = omit<ProgressProps>('size');
+Size.argTypes = omit('size');
 
 export const HideLabel = reactMatrix(Progress, { hideLabel });
-HideLabel.argTypes = omit<ProgressProps>('hideLabel');
+HideLabel.argTypes = omit('hideLabel');
 
-export const WithCustomLabel = (props: ProgressProps) => (
+export const WithCustomLabel: Story<ProgressProps> = (props) => (
   <Progress {...props} />
 );
-WithCustomLabel.argTypes = omit<ProgressProps>('children', 'hideLabel');
+WithCustomLabel.argTypes = omit('children', 'hideLabel');
 WithCustomLabel.args = {
   children: 'Progress: 25%',
   hideLabel: false,
 };
 
-export const ValueLoop = (props: ProgressProps) => {
+export const ValueLoop: Story<ProgressProps> = (props) => {
   const [value, setValue] = useState(0);
 
   useEffect(() => {
@@ -92,7 +92,7 @@ export const ValueLoop = (props: ProgressProps) => {
     </div>
   );
 };
-ValueLoop.argTypes = omit<ProgressProps>('min', 'max', 'value');
+ValueLoop.argTypes = omit('max', 'min', 'value');
 ValueLoop.parameters = {
   docs: {
     source: {
@@ -120,7 +120,7 @@ export const AllCombinations = reactMatrix(
   { hideLabel, size },
   (props) => <Progress {...props} />
 );
-AllCombinations.argTypes = omit<ProgressProps>('hideLabel', 'size');
+AllCombinations.argTypes = omit('hideLabel', 'size');
 AllCombinations.parameters = {
   display: 'grid',
   columns: 'repeat(2, 1fr)',

--- a/packages/react/src/components/radio/radio.stories.tsx
+++ b/packages/react/src/components/radio/radio.stories.tsx
@@ -40,28 +40,26 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<RadioProps>;
 
-export const Playground: Story<RadioProps> = (props: RadioProps) => (
-  <Radio {...props} />
-);
+export const Playground: Story<RadioProps> = (props) => <Radio {...props} />;
 
 export const Bordered = reactMatrix(Radio, { bordered });
-Bordered.argTypes = omit<RadioProps>('bordered');
+Bordered.argTypes = omit('bordered');
 
 export const Invalid = reactMatrix(Radio, { invalid });
-Invalid.argTypes = omit<RadioProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = reactMatrix(Radio, { disabled });
-Disabled.argTypes = omit<RadioProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 interface RadiosWithFieldsetLegendProps extends RadioProps {
   name: string;
   legend: string;
 }
 
-export const WithFieldsetLegend = ({
+export const WithFieldsetLegend: Story<RadiosWithFieldsetLegendProps> = ({
   legend,
   ...restProps
-}: RadiosWithFieldsetLegendProps) => (
+}) => (
   <Fieldset>
     <FieldsetLegend>{legend}</FieldsetLegend>
     <Field>
@@ -76,7 +74,7 @@ export const WithFieldsetLegend = ({
     </Field>
   </Fieldset>
 );
-WithFieldsetLegend.argTypes = omit<RadiosWithFieldsetLegendProps>('children');
+WithFieldsetLegend.argTypes = omit('children');
 WithFieldsetLegend.args = {
   name: 'radios-with-fieldset-legend',
   legend: 'Legend',
@@ -87,11 +85,11 @@ interface RadioWithHelperTextProps extends RadioProps {
   helperText: string;
 }
 
-export const WithHelperText = ({
+export const WithHelperText: Story<RadioWithHelperTextProps> = ({
   label,
   helperText,
   ...restProps
-}: RadioWithHelperTextProps) => (
+}) => (
   <Field>
     <Radio {...restProps}>
       {label}
@@ -99,7 +97,7 @@ export const WithHelperText = ({
     </Radio>
   </Field>
 );
-WithHelperText.argTypes = omit<RadioWithHelperTextProps>('children');
+WithHelperText.argTypes = omit('children');
 WithHelperText.args = {
   label: 'Label',
   helperText: 'Helper text',
@@ -110,11 +108,11 @@ interface RadioWithValidationProps extends RadioProps {
   withIcon: boolean;
 }
 
-export const WithValidation = ({
+export const WithValidation: Story<RadioWithValidationProps> = ({
   validation,
   withIcon,
   ...restProps
-}: RadioWithValidationProps) => (
+}) => (
   <Field>
     <Radio {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
@@ -122,7 +120,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<RadioWithValidationProps>('invalid', 'disabled');
+WithValidation.argTypes = omit('disabled', 'invalid');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,

--- a/packages/react/src/components/search/search.stories.tsx
+++ b/packages/react/src/components/search/search.stories.tsx
@@ -22,9 +22,7 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<SearchProps>;
 
-export const Playground: Story<SearchProps> = (props: SearchProps) => (
-  <Search {...props} />
-);
+export const Playground: Story<SearchProps> = (props) => <Search {...props} />;
 
 export const Disabled = reactMatrix(Search, { disabled });
-Disabled.argTypes = omit<SearchProps>('disabled');
+Disabled.argTypes = omit('disabled');

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -56,20 +56,18 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<SelectProps>;
 
-export const Playground: Story<SelectProps> = (props: SelectProps) => (
-  <Select {...props} />
-);
+export const Playground: Story<SelectProps> = (props) => <Select {...props} />;
 
 export const Borderless = reactMatrix(Select, { borderless });
-Borderless.argTypes = omit<SelectProps>('borderless');
+Borderless.argTypes = omit('borderless');
 
 export const Invalid = reactMatrix(Select, { invalid });
-Invalid.argTypes = omit<SelectProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = reactMatrix(Select, { disabled });
-Disabled.argTypes = omit<SelectProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
-export const AsRequired: Story<SelectProps> = (props: SelectProps) => (
+export const AsRequired: Story<SelectProps> = (props) => (
   <Select {...props} defaultValue={''} />
 );
 AsRequired.args = {
@@ -92,20 +90,16 @@ interface SelectWithLabelAndHelperTextProps extends SelectProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...restProps
-}: SelectWithLabelAndHelperTextProps) => (
-  <Field>
-    <FieldLabel htmlFor={id}>
-      {label}
-      <HelperText>{helperText}</HelperText>
-      <Select {...restProps} id={id} />
-    </FieldLabel>
-  </Field>
-);
+export const WithLabelAndHelperText: Story<SelectWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...restProps }) => (
+    <Field>
+      <FieldLabel htmlFor={id}>
+        {label}
+        <HelperText>{helperText}</HelperText>
+        <Select {...restProps} id={id} />
+      </FieldLabel>
+    </Field>
+  );
 WithLabelAndHelperText.args = {
   id: 'select-with-label-and-helper-text',
   label: 'Label',
@@ -117,11 +111,11 @@ interface SelectWithValidationProps extends SelectProps {
   withIcon: boolean;
 }
 
-export const WithValidation = ({
+export const WithValidation: Story<SelectWithValidationProps> = ({
   validation,
   withIcon,
   ...restProps
-}: SelectWithValidationProps) => (
+}) => (
   <Field>
     <Select {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
@@ -129,10 +123,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<SelectWithValidationProps>(
-  'invalid',
-  'disabled'
-);
+WithValidation.argTypes = omit('disabled', 'invalid');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,
@@ -143,7 +134,7 @@ export const AllCombinations = reactMatrix(
   { borderless, disabled, invalid },
   (props) => <Select {...props}>{children(props)}</Select>
 );
-AllCombinations.argTypes = omit<SelectProps>('children');
+AllCombinations.argTypes = omit('children');
 AllCombinations.args = {
   children: null,
 };

--- a/packages/react/src/components/spinner/spinner.stories.tsx
+++ b/packages/react/src/components/spinner/spinner.stories.tsx
@@ -32,15 +32,17 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<SpinnerProps>;
 
-export const Playground: Story<SpinnerProps> = (props: SpinnerProps) => (
+export const Playground: Story<SpinnerProps> = (props) => (
   <Spinner {...props} />
 );
 
 export const Size = reactMatrix(Spinner, { size });
-Size.argTypes = omit<SpinnerProps>('size');
+Size.argTypes = omit('size');
 
-export const WithoutLabel = (props: SpinnerProps) => <Spinner {...props} />;
-WithoutLabel.argTypes = omit<SpinnerProps>('children');
+export const WithoutLabel: Story<SpinnerProps> = (props) => (
+  <Spinner {...props} />
+);
+WithoutLabel.argTypes = omit('children');
 WithoutLabel.args = {
   children: null,
 };

--- a/packages/react/src/components/textarea/textarea.stories.tsx
+++ b/packages/react/src/components/textarea/textarea.stories.tsx
@@ -17,13 +17,7 @@ import {
 
 const disabled = [true, false] as const;
 const invalid = [true, false] as const;
-
-const resize: readonly TextareaProps['resize'][] = [
-  'vertical',
-  'horizontal',
-  'both',
-  'none',
-];
+const resize = ['vertical', 'horizontal', 'both', 'none'] as const;
 
 export default {
   title: 'React/Textarea',
@@ -63,18 +57,18 @@ export default {
   parameters: { display: 'flex' },
 } as Meta<TextareaProps>;
 
-export const Playground: Story<TextareaProps> = (props: TextareaProps) => (
+export const Playground: Story<TextareaProps> = (props) => (
   <Textarea {...props} />
 );
 
 export const Resize = reactMatrix(Textarea, { resize });
-Resize.argTypes = omit<TextareaProps>('resize');
+Resize.argTypes = omit('resize');
 
 export const Invalid = reactMatrix(Textarea, { invalid });
-Invalid.argTypes = omit<TextareaProps>('invalid');
+Invalid.argTypes = omit('invalid');
 
 export const Disabled = reactMatrix(Textarea, { disabled });
-Disabled.argTypes = omit<TextareaProps>('disabled');
+Disabled.argTypes = omit('disabled');
 
 interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
   id: string;
@@ -82,20 +76,16 @@ interface TextareaWithLabelAndHelperTextProps extends TextareaProps {
   helperText: string;
 }
 
-export const WithLabelAndHelperText = ({
-  id,
-  label,
-  helperText,
-  ...restProps
-}: TextareaWithLabelAndHelperTextProps) => (
-  <Field>
-    <FieldLabel htmlFor={id}>
-      {label}
-      <HelperText>{helperText}</HelperText>
-      <Textarea {...restProps} id={id} />
-    </FieldLabel>
-  </Field>
-);
+export const WithLabelAndHelperText: Story<TextareaWithLabelAndHelperTextProps> =
+  ({ id, label, helperText, ...restProps }) => (
+    <Field>
+      <FieldLabel htmlFor={id}>
+        {label}
+        <HelperText>{helperText}</HelperText>
+        <Textarea {...restProps} id={id} />
+      </FieldLabel>
+    </Field>
+  );
 WithLabelAndHelperText.args = {
   id: 'textarea-with-label-and-helper-text',
   label: 'Label',
@@ -107,11 +97,11 @@ interface TextareaWithValidationProps extends TextareaProps {
   withIcon: boolean;
 }
 
-export const WithValidation = ({
+export const WithValidation: Story<TextareaWithValidationProps> = ({
   validation,
   withIcon,
   ...restProps
-}: TextareaWithValidationProps) => (
+}) => (
   <Field>
     <Textarea {...restProps} invalid={Boolean(validation)} />
     <Validation state="error" withIcon={withIcon}>
@@ -119,10 +109,7 @@ export const WithValidation = ({
     </Validation>
   </Field>
 );
-WithValidation.argTypes = omit<TextareaWithValidationProps>(
-  'invalid',
-  'disabled'
-);
+WithValidation.argTypes = omit('disabled', 'invalid');
 WithValidation.args = {
   validation: 'This field is not valid',
   withIcon: true,


### PR DESCRIPTION
## Purpose

Omit Popover's class in its core story.

The second commit is just a refactor that simplifies types for Stories and the `omit` helper used in them.

## Approach

Add `omit('class')`.
Look for `Story` and `omit` instances to simplify their types.

## Testing

`class` should no longer appear in Core/Popover story table.
Everything else should be the same.

## Risks

None.
