### PR TITLE
docs: better control for Tooltip [show]

### DIFF
--- a/packages/core/src/components/tooltip/tooltip.stories.ts
+++ b/packages/core/src/components/tooltip/tooltip.stories.ts
@@ -33,11 +33,10 @@ export default {
       },
     },
     show: {
-      control: { type: 'boolean' },
+      control: { type: 'inline-radio', options: ['on-hover', true, false] },
       description: [
         '`boolean`: show or hide the Tooltip.',
         '`"on-hover"`: show when the previous sibling matches `:hover` or `:focus`.',
-        'Reset story props (icon on top right of this table) to set "on-hover" again.',
       ].join('\n\n'),
       table: { type: { summary: 'boolean | "on-hover"' } },
     },

--- a/packages/react/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/react/src/components/tooltip/tooltip.stories.tsx
@@ -31,11 +31,10 @@ export default {
       },
     },
     show: {
-      control: { type: 'boolean' },
+      control: { type: 'inline-radio', options: ['on-hover', true, false] },
       description: [
         '`boolean`: show or hide the Tooltip.',
         '`"on-hover"`: show when the previous sibling matches `:hover` or `:focus`.',
-        'Reset story props (icon on top right of this table) to set "on-hover" again.',
       ].join('\n\n'),
       table: { type: { summary: 'boolean | "on-hover"' } },
     },


### PR DESCRIPTION
## Purpose

Use radios instead of boolean and story reset for Tooltip [show].

## Approach

Use story control `inline-radio` rather than `boolean`.

## Testing

Check Tooltip stories.

## Risks

None
