### PR TITLE
chore: optimising sideEffect for importing CSS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,9 @@
   "author": "Onfido",
   "license": "Apache-2.0",
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/onfido/castor.git",


### PR DESCRIPTION
## Purpose

CSS can't be sideEffect free as it does not have an export, therefor when importing css into JS you lose it during the build process. 

## Approach
Excluding it from tree shaking.

## Testing

N/A

## Risks
There is no risk, apart from an effect on bundle size
