### PR TITLE
feat(react): popover screen aware

### DIFF
--- a/packages/react/src/components/popover/popover.tsx
+++ b/packages/react/src/components/popover/popover.tsx
@@ -41,21 +41,23 @@ export function Popover({
     [popover]
   );
 
+  const [optimalPosition, optimalAlignment] = placement;
+
   return target ? (
     <PopoverWithPortal
       {...props}
-      align={placement[1]}
+      align={optimalAlignment}
       onClose={onClose}
       popover={popover}
-      position={placement[0]}
+      position={optimalPosition}
       target={target}
     />
   ) : (
     <PopoverBase
       {...props}
       ref={popover}
-      align={placement[1]}
-      position={placement[0]}
+      align={optimalAlignment}
+      position={optimalPosition}
     />
   );
 }


### PR DESCRIPTION
## Purpose

Make popovers (when used with `target` ref) adjust their placement when intersecting with the viewport.
That is to ensure they would not be hidden depending on content and target placement.

https://user-images.githubusercontent.com/18623773/131711109-a417e36b-8f85-42f6-bc5e-25fddf93259f.mov

## Approach

Use IntersectionObservers to capture events where the popover clips with the viewport.
Then, use an algorithm to find an optimal placement where the popover would not clip.

Works for both use cases, with and without `target` ref.

## Testing

Storybook preview deploy.

## Risks

1. The algorithm can not return to the preferred placement after an intersection event.
It will hold the optimal position until it clips too.

2. React exclusive feature.