### PR TITLE
docs: rename Core to CSS

### DIFF
--- a/packages/core/src/components/button/button.stories.ts
+++ b/packages/core/src/components/button/button.stories.ts
@@ -8,7 +8,7 @@ const kind = ['action', 'destructive'] as const;
 const variant = ['primary', 'secondary', 'tertiary'] as const;
 
 export default {
-  title: 'Core/Button',
+  title: 'CSS/Button',
   component: Button,
   argTypes: {
     children: {},

--- a/packages/core/src/components/field-label/field-label.stories.ts
+++ b/packages/core/src/components/field-label/field-label.stories.ts
@@ -9,7 +9,7 @@ import { Textarea } from '../textarea/textarea.story';
 import { FieldLabel, FieldLabelProps } from './field-label.story';
 
 export default {
-  title: 'Core/FieldLabel',
+  title: 'CSS/FieldLabel',
   component: FieldLabel,
   argTypes: omit('for'),
   args: {

--- a/packages/core/src/components/icon/icon.stories.ts
+++ b/packages/core/src/components/icon/icon.stories.ts
@@ -14,7 +14,7 @@ import { Icon } from './icon.story';
 const [firstIconName] = iconNames;
 
 export default {
-  title: 'Core/Icon',
+  title: 'CSS/Icon',
   component: Icon,
   argTypes: {
     ...omit('aria-hidden'),

--- a/packages/core/src/components/input/input.stories.ts
+++ b/packages/core/src/components/input/input.stories.ts
@@ -24,7 +24,7 @@ const type = [
 ] as const;
 
 export default {
-  title: 'Core/Input',
+  title: 'CSS/Input',
   component: Input,
   argTypes: {
     ...omit('id', 'value'),

--- a/packages/core/src/components/popover/popover.stories.ts
+++ b/packages/core/src/components/popover/popover.stories.ts
@@ -13,7 +13,7 @@ const align = ['center', 'start', 'end'] as const;
 const position = ['top', 'left', 'right', 'bottom'] as const;
 
 export default {
-  title: 'Core/Popover',
+  title: 'CSS/Popover',
   component: Popover,
   argTypes: {
     ...omit('class'),

--- a/packages/core/src/components/progress/progress.stories.ts
+++ b/packages/core/src/components/progress/progress.stories.ts
@@ -12,7 +12,7 @@ const size = ['regular', 'large'] as const;
 const hideLabel = [false, true] as const;
 
 export default {
-  title: 'Core/Progress',
+  title: 'CSS/Progress',
   component: Progress,
   argTypes: {
     ...omit('aria-valuetext'),

--- a/packages/core/src/components/select/select.stories.ts
+++ b/packages/core/src/components/select/select.stories.ts
@@ -10,7 +10,7 @@ const disabled = [true, false] as const;
 const invalid = [true, false] as const;
 
 export default {
-  title: 'Core/Select',
+  title: 'CSS/Select',
   component: Select,
   argTypes: {
     ...omit('class', 'id', 'required', 'value'),

--- a/packages/core/src/components/spinner/spinner.stories.ts
+++ b/packages/core/src/components/spinner/spinner.stories.ts
@@ -10,7 +10,7 @@ import { Spinner, SpinnerProps } from './spinner.story';
 const size = ['large', 'medium', 'small'] as const;
 
 export default {
-  title: 'Core/Spinner',
+  title: 'CSS/Spinner',
   component: Spinner,
   argTypes: {
     children: {

--- a/packages/core/src/components/textarea/textarea.stories.ts
+++ b/packages/core/src/components/textarea/textarea.stories.ts
@@ -15,7 +15,7 @@ const invalid = [true, false] as const;
 const resize = ['vertical', 'horizontal', 'both', 'none'] as const;
 
 export default {
-  title: 'Core/Textarea',
+  title: 'CSS/Textarea',
   component: Textarea,
   argTypes: {
     ...omit('id'),

--- a/packages/core/src/components/tooltip/tooltip.stories.ts
+++ b/packages/core/src/components/tooltip/tooltip.stories.ts
@@ -12,7 +12,7 @@ const align = ['center', 'start', 'end'] as const;
 const position = ['top', 'left', 'right', 'bottom'] as const;
 
 export default {
-  title: 'Core/Tooltip',
+  title: 'CSS/Tooltip',
   component: Tooltip,
   argTypes: {
     align: {


### PR DESCRIPTION
## Purpose

Rename Core/ stories to CSS/

Hopefully that makes it clearer for people unfamiliar with Castor, since "Core" could imply different meanings.

## Risks

Differs from package/folder name, but shouldn't matter much as it's just a visual thing in docs.
