### PR TITLE
fix(react): tooltip type simplification

### DIFF
--- a/packages/react/src/components/tooltip/tooltip.tsx
+++ b/packages/react/src/components/tooltip/tooltip.tsx
@@ -56,7 +56,7 @@ const eventsThatChangeHoverOrFocus = [
 
 const on = <K extends keyof HTMLElementEventMap>(
   element: HTMLElement,
-  type: K | string,
+  type: K,
   listener: (ev: HTMLElementEventMap[K]) => unknown,
   options?: boolean | AddEventListenerOptions
 ) => {


### PR DESCRIPTION
## Purpose

TypeScript <4.4.x doesn't have `string` as part of the eventListener argument union, so type-checking fails on earlier versions.
However we don't need `string` anyway, so we can simplify the type.

## Approach

Remove `string` from the union type (only used internally).

## Testing

Lint with `tsc@4.3.5`

## Risks

None.
