### PR TITLE
Fix / popover and tooltip pointer-events

### DIFF
--- a/packages/core/src/components/popover/popover.scss
+++ b/packages/core/src/components/popover/popover.scss
@@ -9,8 +9,8 @@
 
 @mixin _Popover() {
   .ods-popover-anchor {
-    pointer-events: none;
     position: absolute;
+    visibility: hidden;
     z-index: 9999999;
   }
 
@@ -18,6 +18,7 @@
     height: fit-content;
     max-width: helpers.space(50);
     position: absolute;
+    visibility: initial;
     width: max-content;
 
     // position ==========>

--- a/packages/core/src/components/tooltip/tooltip.scss
+++ b/packages/core/src/components/tooltip/tooltip.scss
@@ -16,18 +16,22 @@
     background-color: helpers.color('background-inverse-surface');
     border-radius: helpers.border-radius('medium');
     color: helpers.color('content-inverse-main');
+    cursor: default;
     height: fit-content;
     line-height: helpers.space(2.25);
     max-width: helpers.space(40);
     opacity: 0;
     padding: helpers.space(1) helpers.space(1.5);
-    pointer-events: none;
     transition: opacity helpers.time(2) ease helpers.time(3),
       visibility helpers.time(5);
     visibility: hidden;
     width: max-content;
 
     &.-show {
+      @include _visible();
+    }
+
+    &.-on-hover:hover {
       @include _visible();
     }
   }


### PR DESCRIPTION
NOTE: will get merged as two different fixes, no squash, but still one PR because the second commit depends on the first

## Purpose

- Allow Popover to have `pointer-events`. Most content inside Popovers are clickable, like a dropdown menu
- Keep Tooltip visible on its own `:hover` state, as well as its target's

## Approach

- Use `visibility` instead of `pointer-events`
- Add `:hover` rule for Tooltip

## Testing

Preview

## Risks

None.
