### PR TITLE
fix(react): button type overloads

### DIFF
--- a/packages/react/src/components/button/button.tsx
+++ b/packages/react/src/components/button/button.tsx
@@ -29,11 +29,13 @@ export const Button: ButtonComponent = withRef(function Button(
 });
 
 export type ButtonProps<T extends 'a' | 'button' = 'button'> = BaseProps &
-  (T extends 'a' ? AnchorElementProps : ButtonElementProps);
+  (T extends 'a'
+    ? { href: string } & AnchorElementProps
+    : { href?: never } & ButtonElementProps);
 
 type ButtonComponent = {
-  (props: BaseProps & AnchorElementProps, ref: AnchorRef): JSX.Element;
-  (props: BaseProps & ButtonElementProps, ref: ButtonRef): JSX.Element;
+  (props: ButtonProps<'a'>, ref: AnchorRef): JSX.Element;
+  (props: ButtonProps<'button'>, ref: ButtonRef): JSX.Element;
 };
 
 type AnchorElementProps = JSX.IntrinsicElements['a'] & { ref?: AnchorRef };


### PR DESCRIPTION
Depends on https://github.com/onfido/castor/pull/1054

## Purpose

Fix `Button` types so that overloaded props are correctly inferred from usage.

Currently, props are merged (TypeScript operator `&`) on inference, e.g.

![Screenshot 2021-10-11 at 17 13 51](https://user-images.githubusercontent.com/18623773/136824058-9d352b0c-2a49-43ab-b459-99a7d5351132.png)

The last one should be an error, `<button />` can not have empty string `''` as `type`.

## Approach

Specify the union difference in `href`.

## Testing

Replicate the scenario in the images, TS error should pop up.

![Screenshot 2021-10-11 at 17 13 28](https://user-images.githubusercontent.com/18623773/136824208-3c0bd2ab-8424-42ff-9a06-38c473fec932.png)

There should also be intellisense available for `type` when `href` is not defined (correct types).

![Screenshot 2021-10-11 at 17 13 39](https://user-images.githubusercontent.com/18623773/136824205-08ff64cc-78c7-40f7-9146-97f1228248f6.png)

## Risks

None.
