### PR TITLE
refactor: use :enabled instead of :not(:disabled)

### DIFF
--- a/packages/core/src/components/checkbox/checkbox.scss
+++ b/packages/core/src/components/checkbox/checkbox.scss
@@ -57,9 +57,9 @@
     }
   }
 
-  // indicating invalid and not [disabled] input
-  .ods-checkbox.-invalid:not(:disabled),
-  .ods-checkbox.-touched:invalid:not(:disabled) {
+  // indicating invalid and :enabled input
+  .ods-checkbox.-invalid:enabled,
+  .ods-checkbox.-touched:invalid:enabled {
     // and [checked] indicator
     &:checked + .ods-input-indicator::after {
       border-color: helpers.color('content-always-light');

--- a/packages/core/src/internal/indicator-container/indicator-container.scss
+++ b/packages/core/src/internal/indicator-container/indicator-container.scss
@@ -88,7 +88,7 @@
 
     > .ods-checkbox,
     > .ods-radio {
-      &:not(:disabled) + .ods-input-indicator {
+      &:enabled + .ods-input-indicator {
         background-color: helpers.color('background-input');
       }
     }


### PR DESCRIPTION
## Purpose

Simplify code a bit.

## Approach

Use `:enabled` rather rather than `:not(:disabled)`

## Testing

There should be no visual change to affected components.

## Risks

None.