### PR TITLE
fix: strict ts issues

### DIFF
--- a/docs/_core/borders/examples.story.tsx
+++ b/docs/_core/borders/examples.story.tsx
@@ -6,18 +6,11 @@ export const Examples = () => (
   <div className={styles.container}>
     <Header>Size</Header>
     <Header>Example</Header>
-    {Object.keys(borderRadii).map((size: BorderRadius) => (
+    {borderRadiusKeys.map((size) => (
       <Row key={size} size={size} />
     ))}
   </div>
 );
-
-const borderRadii = {
-  small: '2px',
-  medium: '4px',
-  large: '8px',
-  full: '100vw',
-};
 
 const Header = ({ children }: { children: string }) => (
   <div className={styles.header}>{children}</div>
@@ -31,3 +24,12 @@ const Row = ({ size }: { size: BorderRadius }) => (
     </div>
   </>
 );
+
+const borderRadii = {
+  small: '2px',
+  medium: '4px',
+  large: '8px',
+  full: '100vw',
+} as const;
+
+const borderRadiusKeys = Object.keys(borderRadii) as BorderRadius[];

--- a/docs/colors/colors.ts
+++ b/docs/colors/colors.ts
@@ -1,7 +1,6 @@
 import { Color } from '@onfido/castor';
 import tokens from './tokens.scss';
 
-export const colors = Object.keys(tokens).reduce((accumulator, name) => {
-  const [, color] = name.match(/^--ods-color-([a-z0-9-]+)$/) ?? [];
-  return color ? [...accumulator, color] : accumulator;
-}, []) as Color[];
+export const colors = Object.keys(tokens)
+  .map((name) => name.match(/^--ods-color-([a-z0-9-]+)$/)?.[1])
+  .filter(Boolean) as Color[];

--- a/docs/helpers/matrix/combinations.ts
+++ b/docs/helpers/matrix/combinations.ts
@@ -17,6 +17,4 @@ export const combinations = <T extends unknown[]>(all: T, next: T): T =>
   // if `all` is an empty array use a placeholder
   combine(all.length ? all : [[]], next)
     // flatten the first element in the tuple
-    .map(([f, s]: Nested) => [...f, s]) as T;
-
-type Nested = [unknown[], unknown];
+    .map(([f, s]) => [...(f as unknown[]), s]) as T;

--- a/packages/react/src/components/form/getFormValues.spec.ts
+++ b/packages/react/src/components/form/getFormValues.spec.ts
@@ -154,6 +154,6 @@ describe('getFormValues', () => {
   });
 });
 
-function hasAttribute(attr: string) {
+function hasAttribute(this: Record<string, unknown>, attr: string) {
   return attr in this;
 }

--- a/packages/react/src/utils/withRef/withRef.ts
+++ b/packages/react/src/utils/withRef/withRef.ts
@@ -5,7 +5,8 @@ import { ForwardedRef, forwardRef, ReactElement } from 'react';
  *
  * @param component Component to `forwardRef`.
  */
-export const withRef = <C extends Forwarded<T, P>, T, P>(component: C): C =>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const withRef = <C extends Forwarded<any, any>>(component: C): C =>
   forwardRef(component) as never;
 
-type Forwarded<T, P> = (props: P, ref: ForwardedRef<T>) => ReactElement | null;
+type Forwarded<P, R> = (props: P, ref: ForwardedRef<R>) => ReactElement | null;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "skipLibCheck": false,
-    "strictNullChecks": true,
+    "strict": true,
 
     "module": "esnext",
     "moduleResolution": "node",


### PR DESCRIPTION
## Purpose

Fix strict TypeScript issues.

Some integrators of 2.0.0 can't use components (e.g. Button) because of a leaky `unknown` type in `withRef`.

## Approach

Enable `strict` in `tsconfig.json`, then fix all type issues.

## Testing

Should pass CI.

## Risks

None, non-strict users can't still use more lax rules.
