### PR TITLE
fix(react): select onChange

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -16,7 +16,6 @@ export interface CustomSelectProps
     PopoverProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  onSelectOption?: (value: string | number | readonly string[]) => void;
 }
 
 export function CustomSelect({
@@ -32,7 +31,6 @@ export function CustomSelect({
   onClick,
   onKeyUp,
   onOpenChange,
-  onSelectOption,
   ...restProps
 }: CustomSelectProps) {
   const selectRef = useRef<HTMLSelectElement>(null);
@@ -67,7 +65,14 @@ export function CustomSelect({
           setSelectedOption(option);
           setValue(value);
           close();
-          onSelectOption?.(value);
+          // propagate onChange manually because <select> won't naturally when
+          // its value is changed programatically by React, and on next tick
+          // because React needs to update its value first
+          setTimeout(() =>
+            selectRef.current?.dispatchEvent(
+              new Event('change', { bubbles: true })
+            )
+          );
         },
       }}
     >

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -21,7 +21,7 @@ export default {
   title: 'React/Select',
   component: Select,
   argTypes: {
-    ...omit<CustomSelectProps>('open', 'onOpenChange', 'onSelectOption'),
+    ...omit<CustomSelectProps>('open', 'onOpenChange'),
     align: {
       control: 'inline-radio',
       table: { defaultValue: { summary: 'start' } },

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -8,7 +8,7 @@ import { SelectProvider } from './useSelect';
 export type SelectProps =
   | ({ native: true } & BaseProps & NativeSelectProps)
   | ({ native?: false } & BaseProps &
-      Omit<CustomSelectProps, 'open' | 'onOpenChange' | 'onSelectOption'>);
+      Omit<CustomSelectProps, 'open' | 'onOpenChange'>);
 
 /**
  * `Select` uses an `Icon` that requires `Icons` (SVG sprite) to be included in
@@ -20,6 +20,7 @@ export const Select = ({
   borderless,
   className,
   native,
+  onChange,
   ...restProps
 }: SelectProps) => {
   const { defaultValue, value } = restProps;
@@ -38,7 +39,10 @@ export const Select = ({
           borderless={borderless}
           native={native}
           open={open}
-          onEmptyChange={setEmpty}
+          onChange={(event) => {
+            setEmpty(!event.currentTarget.value);
+            onChange?.(event);
+          }}
           onOpenChange={setOpen}
         />
         <Icon name="chevron-down" aria-hidden="true" />
@@ -51,7 +55,6 @@ interface ContentProps extends CustomSelectProps {
   borderless?: boolean;
   native?: boolean;
   open?: boolean;
-  onEmptyChange: (empty: boolean) => void;
   onOpenChange: (open: boolean) => void;
 }
 
@@ -59,21 +62,10 @@ function Content({
   borderless,
   native,
   open,
-  onChange,
-  onEmptyChange,
   onOpenChange,
   ...restProps
 }: ContentProps) {
-  if (native)
-    return (
-      <NativeSelect
-        {...restProps}
-        onChange={(event) => {
-          onEmptyChange(!event.currentTarget.value);
-          onChange?.(event);
-        }}
-      />
-    );
+  if (native) return <NativeSelect {...restProps} />;
 
   return (
     <CustomSelect
@@ -81,7 +73,6 @@ function Content({
       borderless={borderless}
       open={open}
       onOpenChange={onOpenChange}
-      onSelectOption={(value) => onEmptyChange(!value)}
     />
   );
 }


### PR DESCRIPTION
## Purpose

React `<Select/>` is not emitting `onChange` events.
Fix it so it does.

## Approach

Inside `<CustomSelect/>`, when the `select` function is called, emit a synthetic event for 'change' from the native `<select/>` as if the user selected the option directly in it, instead of React modifying its value which is what actually happens.

## Testing

- `onChange={console.log}` listener temporarily added in story to confirm.
- internal Onfido app Signal Builder (where we found the bug) has an e2e test that depends on that event, after the change it passes

## Risks

If anything it reduces risk
