### PR TITLE
fix(react): select empty modifier

### DIFF
--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -27,7 +27,9 @@ export const Select = ({
   const [empty, setEmpty] = useState(!(value ?? defaultValue));
   const [open, setOpen] = useState(false);
 
-  useEffect(() => setEmpty(!value), [value]);
+  useEffect(() => {
+    if (defaultValue == null) setEmpty(!value);
+  }, [value]);
 
   return (
     <div

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -28,7 +28,7 @@ export const Select = ({
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
-    if (defaultValue == null) setEmpty(!value);
+    if (value != null) setEmpty(!value);
   }, [value]);
 
   return (


### PR DESCRIPTION
## Purpose

Select `.-empty` modifier (for placeholders) is incorrectly applied when `defaultValue` is used, rather than `value`.

## Approach

The problem is that the useEffect hook that trigger on `value` changes also triggers on first render, just after `useState(empty)`.

In that hook, we should only `setEmpty` if `defaultValue` is not defined.

## Testing

Found in Signal Builder, reproduced and fixed in Storybook

## Risks

None.
