### PR TITLE
fix(react): hidden options do not render

### DIFF
--- a/packages/react/src/components/select/custom/custom-option.tsx
+++ b/packages/react/src/components/select/custom/custom-option.tsx
@@ -13,6 +13,7 @@ export function CustomOption({
   children,
   className,
   disabled,
+  hidden,
   value: optionValue,
   onClick,
   onKeyUp,
@@ -22,8 +23,9 @@ export function CustomOption({
 
   useEffect(() => initialize(children, optionValue), []);
 
-  const selectOption = () => disabled || select(children, optionValue);
+  if (hidden) return null;
 
+  const selectOption = () => disabled || select(children, optionValue);
   const selected = value == optionValue;
 
   return (


### PR DESCRIPTION
## Purpose

Non-native `<Select />` does not respect `[hidden]` attribute in `<Option />`.

`<Option hidden />` should not render, same as in native selects.

Useful for placeholders that you do not want in your popover/dropdown.

```tsx
<Select>
  <Option hidden>Select an option...</Option>
</Select>
```

Using `disabled` works, but fits a different use case, in which you want the placeholder to be visible in the dropdown but not selectable.

## Approach

In `CustomOption` return `null` if `hidden` is truthy.

## Testing

Found in Signal Builder, reproduced and fixed in Storybook

## Risks

None
