### PR TITLE
fix(react): select should respond to value changes

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -2,6 +2,7 @@ import { c, classy, m, PopoverProps, SelectProps } from '@onfido/castor';
 import React, {
   ReactNode,
   SyntheticEvent,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -31,11 +32,19 @@ export function CustomSelect({
   onClick,
   onKeyUp,
   onOpenChange,
+  value,
   ...restProps
 }: CustomSelectProps) {
   const selectRef = useRef<HTMLSelectElement>(null);
-  const [selectedOption, setSelectedOption] = useState<ReactNode>();
-  const [value, setValue] = useState(restProps.value ?? defaultValue);
+  const options = useRef(new Map<typeof value, ReactNode>());
+  const [currentValue, setCurrentValue] = useState<typeof value>();
+
+  // default to first option after first render
+  useEffect(() => setCurrentValue(value ?? defaultValue), []);
+
+  useEffect(() => {
+    if (value != null) setCurrentValue(value);
+  }, [value]);
 
   const name = useMemo(
     () => initialName || `castor-select-${++id}`,
@@ -43,27 +52,26 @@ export function CustomSelect({
   );
 
   const open = () => onOpenChange?.(true);
-
   const close = () => {
     onOpenChange?.(false);
     focus(selectRef.current);
   };
+
+  const selectedOption = options.current.get(currentValue);
 
   return (
     <CustomSelectProvider
       value={{
         name,
         selectedOption,
-        value,
+        value: currentValue,
         initialize(option, optionValue) {
-          // initial value
-          if (value == optionValue) setSelectedOption(option);
-          // or default to first option
-          else setSelectedOption((current) => current ?? option);
+          options.current.set(optionValue, option);
         },
-        select(option, value) {
-          setSelectedOption(option);
-          setValue(value);
+        select(option, optionValue) {
+          // if there are repeated keys, make the selected one take priority
+          options.current.set(optionValue, option);
+          setCurrentValue(optionValue);
           close();
           // propagate onChange manually because <select> won't naturally when
           // its value is changed programatically by React, and on next tick
@@ -96,7 +104,7 @@ export function CustomSelect({
           onKeyUp?.(event);
         }}
       >
-        {!value || <option hidden value={value} />}
+        {!currentValue || <option hidden value={currentValue} />}
       </NativeSelect>
 
       <output className={classy(c('select-output'))}>{selectedOption}</output>

--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -39,7 +39,7 @@ export function CustomSelect({
   const options = useRef(new Map<typeof value, ReactNode>());
   const [currentValue, setCurrentValue] = useState<typeof value>();
 
-  // default to first option after first render
+  // default to first option on first render
   useEffect(() => setCurrentValue(value ?? defaultValue), []);
 
   useEffect(() => {


### PR DESCRIPTION
## Purpose

React's `<Select />` does not update when its `value` changes, but it should.

## Approach

Introduce `useEffect` hooks that set internal value when it changes.
Also change `initialize` a bit so that the correct option JSX can be found with its value as key.

## Testing

Storybook with `value` property defined and changed with, for example, hooks and buttons

## Risks

Slightly increases `Select`'s bundle size
