### PR TITLE
docs: select options - hidden instead of disabled

### DIFF
--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -42,7 +42,7 @@ export default {
   args: {
     children: (
       <>
-        <Option disabled value="">
+        <Option hidden value="">
           Select an option...
         </Option>
         <Option value={1}>Option 1</Option>


### PR DESCRIPTION
## Purpose

We use `disabled` in core/CSS/native Select because using `hidden` creates a bad user experience, as the next first option seems to be select by default.

![Screenshot 2021-11-24 at 16 14 50](https://user-images.githubusercontent.com/18623773/143274983-b05df118-904d-433f-96c9-6062878179b2.png)
![image](https://user-images.githubusercontent.com/18623773/143274958-dbc21ab3-f1a1-486c-920a-5e27ce02941c.png)

However, in our "arguably better UX" version of Select, we can use `hidden` instead for a better "placeholder" experience.

![image](https://user-images.githubusercontent.com/18623773/143275084-3e8934d3-3392-42b8-a47b-d73d592235e6.png)

## Approach

Change `disabled` for `hidden`.

## Testing

Storybook.

## Risks

People might use `hidden` for `<Select native />`, which is fine but not ideal
