### PR TITLE
docs: set reactMatrix keys to stop console.error

### DIFF
--- a/docs/helpers/matrix/reactMatrix.tsx
+++ b/docs/helpers/matrix/reactMatrix.tsx
@@ -30,12 +30,24 @@ import { Entries } from './types';
 export function reactMatrix<Props extends Record<string, any>>(
   Component: FC<Props>,
   props: Entries<Props>,
-  render: Render<Props> = (p) => <Component {...p} />
+  Render: Render<Props> = (p) => <Component {...p} />
 ): Story<Props> {
   const entries = getEntries(props);
 
   return (storyProps: Props) =>
-    entries.map((matrixProps) => render({ ...storyProps, ...matrixProps }));
+    entries.map((matrixProps) => (
+      <Render key={random()} {...storyProps} {...matrixProps} />
+    ));
 }
 
+const random = () =>
+  crypto.randomUUID?.() || crypto.getRandomValues(new Int32Array(1))[0];
+
 type Render<Props> = (props: Props) => JSX.Element;
+
+// TODO: remove when updated in TypeScript DOM definitions
+declare global {
+  interface Crypto {
+    randomUUID?: () => string;
+  }
+}


### PR DESCRIPTION
## Purpose

Prevent `console.error`s that show up in stories because `key` is not set.

## Approach

Set a key for each component rendered inside `reactMatrix`.

## Testing

Open Storybook locally, go to a story that uses the matrix such as Select's, check console for errors

## Risks

None
