### PR TITLE
fix(react): condition for Select's options render

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -151,8 +151,8 @@ export function CustomSelect({
         </Popover>
       )}
 
-      {/* render once to find output */}
-      {!selectedOption && <div style={{ display: 'none' }}>{children}</div>}
+      {/* render once to initialize options */}
+      {!options.current.size && <div hidden>{children}</div>}
     </CustomSelectProvider>
   );
 }


### PR DESCRIPTION
## Purpose

Improve the condition for Select's options to render, otherwise a nullish `selectedOption` would incorrectly render it.

## Approach

Use `options.size` instead, which is always `0` before the initialisation, and in case there are no `children` will simply render an empty `<div>`

## Testing

Storybook

## Risks

None, if no `children` is provided an empty `<div>` will be rendered.
