### PR TITLE
fix(react): ensure output's height

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -115,7 +115,10 @@ export function CustomSelect({
         {!currentValue || <option hidden value={currentValue} />}
       </NativeSelect>
 
-      <output className={classy(c('select-output'))}>{selectedOption}</output>
+      <output className={classy(c('select-output'))}>
+        {/* no-break space guarantees element height */}
+        {selectedOption}&nbsp;
+      </output>
 
       {isOpen && (
         <Popover

--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -116,8 +116,8 @@ export function CustomSelect({
       </NativeSelect>
 
       <output className={classy(c('select-output'))}>
-        {/* no-break space guarantees element height */}
-        {selectedOption}&nbsp;
+        {selectedOption}
+        &nbsp; {/* no-break space guarantees element height */}
       </output>
 
       {isOpen && (


### PR DESCRIPTION
## Purpose

Make sure Select has consistent height even if no output is rendered, when there are no options in it.

## Approach

Always print a no-break-space at the end, ensuring the line-height will be applied by the browser.

## Testing

Storybook, provide no children for a Select component.

## Risks

None, does not affect its value or visuals.
