### PR TITLE
fix(react): expose Select's ref

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -1,5 +1,6 @@
 import { c, classy, m, PopoverProps, SelectProps } from '@onfido/castor';
 import React, {
+  ForwardedRef,
   ReactNode,
   SyntheticEvent,
   useEffect,
@@ -7,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useForwardedRef, withRef } from '../../../utils';
 import { Popover } from '../../popover/popover';
 import { NativeSelect, NativeSelectProps } from '../native';
 import { CustomSelectProvider } from './useCustomSelect';
@@ -19,23 +21,26 @@ export interface CustomSelectProps
   onOpenChange?: (open: boolean) => void;
 }
 
-export function CustomSelect({
-  align = 'start',
-  borderless,
-  children,
-  className,
-  defaultValue,
-  name: initialName,
-  open: isOpen,
-  position = 'bottom',
-  onBlur,
-  onClick,
-  onKeyUp,
-  onOpenChange,
-  value,
-  ...restProps
-}: CustomSelectProps) {
-  const selectRef = useRef<HTMLSelectElement>(null);
+export const CustomSelect = withRef(function CustomSelect(
+  {
+    align = 'start',
+    borderless,
+    children,
+    className,
+    defaultValue,
+    name: initialName,
+    open: isOpen,
+    position = 'bottom',
+    onBlur,
+    onClick,
+    onKeyUp,
+    onOpenChange,
+    value,
+    ...restProps
+  }: CustomSelectProps,
+  ref: ForwardedRef<HTMLSelectElement>
+) {
+  const selectRef = useForwardedRef(ref);
   const options = useRef(new Map<typeof value, ReactNode>());
 
   // initialize with empty array to ensure re-render even with nullish value
@@ -155,7 +160,7 @@ export function CustomSelect({
       {!selectedOption && <div style={{ display: 'none' }}>{children}</div>}
     </CustomSelectProvider>
   );
-}
+});
 
 const closeSelectKeys = new Set(['Escape']);
 const openSelectKeys = new Set([' ', 'ArrowDown', 'ArrowUp']);

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -1,6 +1,7 @@
 import { c, classy, m, SelectProps as BaseProps } from '@onfido/castor';
 import { Icon } from '@onfido/castor-react';
-import React, { useEffect, useState } from 'react';
+import React, { ForwardedRef, useEffect, useState } from 'react';
+import { withRef } from '../../utils';
 import { CustomSelect, CustomSelectProps } from './custom';
 import { NativeSelect, NativeSelectProps } from './native';
 import { SelectProvider } from './useSelect';
@@ -16,13 +17,10 @@ export type SelectProps =
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
  */
-export const Select = ({
-  borderless,
-  className,
-  native,
-  onChange,
-  ...restProps
-}: SelectProps) => {
+export const Select = withRef(function Select(
+  { borderless, className, native, onChange, ...restProps }: SelectProps,
+  ref: ForwardedRef<HTMLSelectElement>
+) {
   const { defaultValue, value } = restProps;
   const [empty, setEmpty] = useState(!(value ?? defaultValue));
   const [open, setOpen] = useState(false);
@@ -38,6 +36,7 @@ export const Select = ({
       <SelectProvider value={{ native }}>
         <Content
           {...restProps}
+          ref={ref}
           borderless={borderless}
           native={native}
           open={open}
@@ -51,7 +50,7 @@ export const Select = ({
       </SelectProvider>
     </div>
   );
-};
+});
 
 interface ContentProps extends CustomSelectProps {
   borderless?: boolean;
@@ -60,21 +59,19 @@ interface ContentProps extends CustomSelectProps {
   onOpenChange: (open: boolean) => void;
 }
 
-function Content({
-  borderless,
-  native,
-  open,
-  onOpenChange,
-  ...restProps
-}: ContentProps) {
-  if (native) return <NativeSelect {...restProps} />;
+const Content = withRef(function Content(
+  { borderless, native, open, onOpenChange, ...restProps }: ContentProps,
+  ref: ForwardedRef<HTMLSelectElement>
+) {
+  if (native) return <NativeSelect {...restProps} ref={ref} />;
 
   return (
     <CustomSelect
       {...restProps}
+      ref={ref}
       borderless={borderless}
       open={open}
       onOpenChange={onOpenChange}
     />
   );
-}
+});

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './partitionObject/partitionObject';
 export * from './useDebounce/useDebounce';
+export * from './useForwardedRef/useForwardedRef';
 export * from './useNoScroll/useNoScroll';
 export * from './useObserver';
 export * from './useOnClickOutside/useOnClickOutside';

--- a/packages/react/src/utils/useForwardedRef/useForwardedRef.spec.ts
+++ b/packages/react/src/utils/useForwardedRef/useForwardedRef.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { useForwardedRef } from './useForwardedRef';
+
+jest.mock('react', () => ({
+  useEffect: (callback: any) => callback(),
+  useRef: () => ({ current: {} }),
+}));
+
+describe('useForwardedRef', () => {
+  it('should normalise a function into a mutable object', () => {
+    let current;
+    const forwardedRef = (ref: any) => void (current = ref);
+
+    const ref = useForwardedRef(forwardedRef);
+
+    expect(ref.current).toBe(current);
+  });
+
+  it('should share the same "current" pointer between two object refs', () => {
+    const forwardedRef = { current: undefined };
+
+    const ref = useForwardedRef(forwardedRef);
+
+    expect(ref.current).toBe(forwardedRef.current);
+  });
+
+  it('should gracefully ignore null refs', () => {
+    const ref = useForwardedRef(null);
+
+    expect(ref.current).toBeDefined();
+  });
+});

--- a/packages/react/src/utils/useForwardedRef/useForwardedRef.ts
+++ b/packages/react/src/utils/useForwardedRef/useForwardedRef.ts
@@ -1,0 +1,16 @@
+import { ForwardedRef, useEffect, useRef } from 'react';
+
+/**
+ * Normalizes a forwarded ref into a ref object.
+ * @param ref Forwarded ref.
+ */
+export function useForwardedRef<T>(ref: ForwardedRef<T>) {
+  const mutableRef = useRef<T>(null);
+
+  useEffect(() => {
+    if (typeof ref === 'function') ref(mutableRef.current);
+    else if (ref) ref.current = mutableRef.current;
+  }, []);
+
+  return mutableRef;
+}


### PR DESCRIPTION
## Purpose

Expose Select's ref.

## Approach

Use `withRef` and introduce new helper `useForwardedRef` to normalise a ref (function vs object) internally

## Testing

Storybook, provide a reference to a Select component

## Risks

None
