### PR TITLE
fix(react): defaults Select to first option

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -37,11 +37,19 @@ export function CustomSelect({
 }: CustomSelectProps) {
   const selectRef = useRef<HTMLSelectElement>(null);
   const options = useRef(new Map<typeof value, ReactNode>());
-  const [currentValue, setCurrentValue] = useState<typeof value>();
 
-  // default to first option on first render
+  // initialize with empty array to ensure re-render even with nullish value
+  const [currentValue, _setCurrentValue] = useState<typeof value>([]);
+  const setCurrentValue = (value: typeof currentValue) =>
+    // default to first option if value is not in options
+    _setCurrentValue(
+      options.current.has(value) ? value : options.current.keys().next().value
+    );
+
+  // set initial value only after options have been initialized
   useEffect(() => setCurrentValue(value ?? defaultValue), []);
 
+  // set value every time it changes and it's not nullish
   useEffect(() => {
     if (value != null) setCurrentValue(value);
   }, [value]);


### PR DESCRIPTION
## Purpose

Ensure it's impossible to not have an option selected.

## Approach

In case the value provided has no related option, default to the first.
Also ensures a re-render on every option selection change, even if its value is nullish, so that it renders output correctly.

## Testing

Storybook, provide `value` prop in story which does not match any available Option.

## Risks

None
