### PR TITLE
chore: rename imports because of deprecation

### DIFF
--- a/docs/_core/_core.stories.tsx
+++ b/docs/_core/_core.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories } from '@storybook/addon-docs/blocks';
+import { Primary, Stories } from '@storybook/addon-docs';
 import React from 'react';
 
 const docsPage = () => (

--- a/docs/_core/borders/borders.stories.tsx
+++ b/docs/_core/borders/borders.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Primary, Stories, Title } from '@storybook/addon-docs';
 import React from 'react';
 import { Examples } from './examples.story';
 import { Helpers } from './helpers.story';

--- a/docs/_core/colors/colors.stories.tsx
+++ b/docs/_core/colors/colors.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Primary, Stories, Title } from '@storybook/addon-docs';
 import React from 'react';
 import { Helpers } from './helpers.story';
 import { Intro } from './intro.story';

--- a/docs/_core/spacing/spacing.stories.tsx
+++ b/docs/_core/spacing/spacing.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Primary, Stories, Title } from '@storybook/addon-docs';
 import React from 'react';
 import { Examples } from './examples.story';
 import { Helpers } from './helpers.story';

--- a/docs/_core/theming/theming.stories.tsx
+++ b/docs/_core/theming/theming.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Primary, Stories, Title } from '@storybook/addon-docs';
 import React from 'react';
 import { CreatingTheme } from './creating-theme.story';
 import { Intro } from './intro.story';

--- a/docs/_core/typography/typography.stories.tsx
+++ b/docs/_core/typography/typography.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories, Title } from '@storybook/addon-docs/blocks';
+import { Primary, Stories, Title } from '@storybook/addon-docs';
 import React from 'react';
 import { Examples } from './examples.story';
 import { Helpers } from './helpers.story';

--- a/docs/_react/_react.stories.tsx
+++ b/docs/_react/_react.stories.tsx
@@ -1,4 +1,4 @@
-import { Primary, Stories } from '@storybook/addon-docs/blocks';
+import { Primary, Stories } from '@storybook/addon-docs';
 import React from 'react';
 
 const docsPage = () => (


### PR DESCRIPTION
## Purpose

Follow Storybook deprecation's instructions.

## Approach

Rename imports from `'@storybook/addon-docs/blocks'` to `'@storybook/addon-docs'`

## Risks

None
