### PR TITLE
docs: color examples

### DIFF
--- a/docs/_core/colors/colors.scss
+++ b/docs/_core/colors/colors.scss
@@ -1,0 +1,55 @@
+@use '~@onfido/castor';
+
+.cards {
+  display: flex;
+  flex-direction: column;
+  gap: castor.space(4);
+  margin: castor.space(-4);
+}
+
+.title {
+  @include castor.font('500-bold');
+  margin: 0;
+  margin-left: castor.space(3);
+  text-transform: capitalize;
+}
+
+.preview {
+  @include castor.font('400-bold');
+  align-items: center;
+  display: flex;
+  display: grid;
+  flex-wrap: wrap;
+  grid: auto / 1fr 1fr 1fr;
+}
+
+.color {
+  @include castor.font('300-regular');
+  align-items: center;
+  display: flex;
+  gap: castor.space(1);
+  justify-content: start;
+  line-height: 1;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.name {
+  color: castor.color('content-main');
+  display: flex;
+  flex-direction: column;
+  gap: castor.space(0.5);
+}
+
+.secondary {
+  @include castor.font('200-regular');
+  color: castor.color('content-secondary');
+}
+
+.circle {
+  border: castor.space(0.125) solid castor.color('background-surface-alt');
+  border-radius: castor.border-radius('full');
+  display: inline-block;
+  height: castor.space(4.5);
+  width: castor.space(4.5);
+}

--- a/docs/_core/colors/colors.stories.tsx
+++ b/docs/_core/colors/colors.stories.tsx
@@ -1,6 +1,8 @@
 // eslint-disable-next-line storybook/story-exports
 import { Primary, Stories, Title } from '@storybook/addon-docs';
+import { Meta } from '@storybook/react/types-7-0';
 import React from 'react';
+import { Examples } from './examples.story';
 import { Helpers } from './helpers.story';
 import { Intro } from './intro.story';
 
@@ -17,6 +19,6 @@ export default {
       ),
     },
   },
-};
+} as Meta;
 
-export { Intro, Helpers };
+export { Intro, Examples, Helpers };

--- a/docs/_core/colors/examples.story.tsx
+++ b/docs/_core/colors/examples.story.tsx
@@ -1,0 +1,100 @@
+import { Color, color } from '@onfido/castor';
+import { Button, Tooltip } from '@onfido/castor-react';
+import React, { useRef, useState } from 'react';
+import { colors, tokens } from '../..';
+import styles from './colors.scss';
+
+export const Examples = () => {
+  const timeout = useRef<number>();
+  const [fakeRef, setFakeRef] = useState<{ current: HTMLElement }>();
+
+  const theme = currentTheme();
+
+  return (
+    <div className={styles.cards}>
+      {orderedColors.map(([title, groups]) => (
+        <>
+          <h2 className={styles.title}>{title}</h2>
+          {groups.map(([group, colors]) => (
+            <ColorPreview
+              key={group}
+              colors={colors}
+              tokens={tokens[theme]}
+              onColor={(color, element) => {
+                clearTimeout(timeout.current);
+                timeout.current = setTimeout(setFakeRef, 3000);
+                setFakeRef(undefined);
+                setTimeout(() => setFakeRef({ current: element }));
+                copyToClipboard(color);
+              }}
+            />
+          ))}
+        </>
+      ))}
+
+      <Tooltip target={fakeRef} show={!!fakeRef}>
+        Copied to clipboard
+      </Tooltip>
+    </div>
+  );
+};
+
+const currentTheme = () =>
+  (document
+    .querySelector('[class*="castor-theme"]')
+    ?.className.replace(
+      /.*\bcastor-theme--(\w+)\b.*/,
+      '$1'
+    ) as keyof typeof tokens) || 'day';
+
+const groupColors = (filterRegex: RegExp) =>
+  Object.entries(
+    colors
+      .filter((color) => filterRegex.test(color))
+      .reduce((groups, color) => {
+        const [group] = color.split('-');
+        (groups[group] ??= []).push(color);
+        return groups;
+      }, {} as Record<string, Color[]>)
+  );
+
+const themeColors = groupColors(/^content-|^background-|^border-/);
+const paletteColors = groupColors(/-\d{3}$|-black$|-white$/);
+
+const orderedColors = [
+  ['Theme', themeColors],
+  ['Palette', paletteColors],
+] as const;
+
+interface ColorPreviewProps {
+  colors: Color[];
+  onColor: (color: Color, element: HTMLElement) => void;
+  tokens: typeof tokens['day'];
+}
+
+const ColorPreview = ({ colors, onColor, tokens }: ColorPreviewProps) => (
+  <div className={styles.preview}>
+    {colors.map((color) => (
+      <Button
+        key={color}
+        className={styles.color}
+        variant="tertiary"
+        onClick={(ev) => onColor(color, ev.currentTarget)}
+      >
+        <Circle color={color} />
+        <div className={styles.name}>
+          <span>{color}</span>
+          <span className={styles.secondary}>{tokens['color-' + color]}</span>
+        </div>
+      </Button>
+    ))}
+  </div>
+);
+
+const Circle = ({ color: c }: { color: Color }) => (
+  <span className={styles.circle} style={{ backgroundColor: color(c) }} />
+);
+
+function copyToClipboard(content: string) {
+  navigator.clipboard.writeText(content);
+}

--- a/docs/_core/colors/helpers.story.tsx
+++ b/docs/_core/colors/helpers.story.tsx
@@ -38,7 +38,7 @@ export const Helpers = () => (
     <h4>Color Palette</h4>
     <p>
       You may also use colors directly from palette, providing an optional alpha
-      channel. However, theming support is then limited.
+      channel (opacity). However, theming support is then limited.
     </p>
     <h5>Sass</h5>
     <Source

--- a/docs/_core/colors/intro.story.tsx
+++ b/docs/_core/colors/intro.story.tsx
@@ -20,7 +20,7 @@ export const Intro = () => (
       language="css"
       code={`
         .text {
-          color: var(--ods-color-content-main);
+          color: rgba(var(--ods-color-content-main));
         }
       `}
       format

--- a/docs/colors/colors.ts
+++ b/docs/colors/colors.ts
@@ -1,6 +1,37 @@
 import { Color } from '@onfido/castor';
-import tokens from './tokens.scss';
+import day from './day.scss';
+import night from './night.scss';
 
-export const colors = Object.keys(tokens)
-  .map((name) => name.match(/^--ods-color-([a-z0-9-]+)$/)?.[1])
+export const colors = Object.keys({ ...day, ...night })
+  .map((name) => name.match(/^--ods-color-(.+)/)?.[1])
   .filter(Boolean) as Color[];
+
+export const tokens = {
+  day: tokensFor(day),
+  night: tokensFor(night),
+};
+
+function tokensFor(theme: typeof day) {
+  return Object.fromEntries(
+    Object.entries(theme).map(([key, value]) => [
+      key.replace('--ods-', ''),
+      readable(value),
+    ])
+  );
+}
+
+function readable(value: string) {
+  // theme colors
+  if (value.startsWith('var(--ods-color'))
+    return value.replace(
+      /var\(--ods-color-(.+)\), ([\d.]+)/,
+      (_, variable: string, opacity: string) =>
+        variable + (+opacity < 1 ? ` / ${+opacity * 100}%` : '')
+    );
+
+  // palette colors
+  if (/\d{1,3}, \d{1,3}, \d{1,3}/.test(value))
+    return `rgb(${value.replaceAll(',', '')})`;
+
+  return value;
+}

--- a/docs/colors/day.scss
+++ b/docs/colors/day.scss
@@ -1,0 +1,5 @@
+@use '~@onfido/castor';
+
+:export {
+  @include castor.day();
+}

--- a/docs/colors/night.scss
+++ b/docs/colors/night.scss
@@ -1,6 +1,5 @@
 @use '~@onfido/castor';
 
 :export {
-  @include castor.day();
   @include castor.night();
 }


### PR DESCRIPTION
## Purpose

Add examples to color documentation.

## Approach

Display all colours dynamically depending on theme selected.

## Testing

Storybook > Castor > Color > Examples

## Risks

- ~~Non-component stories are currently out of order, but that regression was introduced some time ago.~~
  ~~Will open another PR to fix that~~
  Actually that only happens locally, less priority then

- Not the best visualisation, but sets a minimum that we can improve over time.
  Documentation as a whole will continue to be worked on in the near future
