### PR TITLE
docs: syntax highlight for sass

### DIFF
--- a/docs/_core/borders/helpers.story.tsx
+++ b/docs/_core/borders/helpers.story.tsx
@@ -6,7 +6,7 @@ export const Helpers = () => (
     <p>Use one of allowed sizes when setting border radius of an element.</p>
     <h4>Sass</h4>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 

--- a/docs/_core/colors/helpers.story.tsx
+++ b/docs/_core/colors/helpers.story.tsx
@@ -10,7 +10,7 @@ export const Helpers = () => (
     </p>
     <h5>Sass</h5>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 
@@ -42,7 +42,7 @@ export const Helpers = () => (
     </p>
     <h5>Sass</h5>
     <Source
-      language="scss"
+      language="css"
       code={`
         .box {
           background-color: castor.color('primary-500', 0.5);

--- a/docs/_core/spacing/helpers.story.tsx
+++ b/docs/_core/spacing/helpers.story.tsx
@@ -9,7 +9,7 @@ export const Helpers = () => (
     </p>
     <h4>Sass</h4>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 

--- a/docs/_core/theming/creating-theme.story.tsx
+++ b/docs/_core/theming/creating-theme.story.tsx
@@ -15,7 +15,7 @@ export const CreatingTheme = () => (
       &#34;day&#34; theme, and then to change some theme tokens:
     </p>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 
@@ -35,7 +35,7 @@ export const CreatingTheme = () => (
       Or by extending &#34;night&#34; theme, and then changing some base tokens:
     </p>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 
@@ -68,7 +68,7 @@ export const CreatingTheme = () => (
       themes, but instead override base tokens:
     </p>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 

--- a/docs/_core/theming/intro.story.tsx
+++ b/docs/_core/theming/intro.story.tsx
@@ -70,7 +70,7 @@ export const Intro = () => (
       If you prefer, you may also include class themes within your Sass file:
     </p>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 
@@ -85,7 +85,7 @@ export const Intro = () => (
       &#34;raw&#34; versions:
     </p>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 

--- a/docs/_core/typography/helpers.story.tsx
+++ b/docs/_core/typography/helpers.story.tsx
@@ -9,7 +9,7 @@ export const Helpers = () => (
     </p>
     <h4>Sass</h4>
     <Source
-      language="scss"
+      language="css"
       code={`
         @use '~@onfido/castor';
 


### PR DESCRIPTION
## Purpose

Fix Sass/CSS syntax highlight in stories.

## Approach

Use `css` rather than `scss` or `sass` since only the first is supported.

## Testing

Storybook -> Castor stories

## Risks

None
