### PR TITLE
build: update dependabot npm rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,5 @@ updates:
         versions: ['>= 11.0.0']
       - dependency-name: 'webpack'
         versions: ['>= 5.0.0']
+      - dependency-name: 'webpack-dev-server'
+        versions: ['>= 4.0.0']


### PR DESCRIPTION
## Purpose

Ignore `webpack-dev-server` in `examples/react-scss-js-webpack` too

## Approach

Update `.dependabot.yml`

## Testing

After merge should not open any dependabot PRs for that dependency

