### PR TITLE
chore: include modules in src/tsconfig

### DIFF
--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "../../tsconfig.json",
-  "include": ["**/*"],
+  "include": ["**/*", "../modules.d.ts"],
   "exclude": ["**/*.spec.*", "**/*.stories.*", "**/*.story.*"],
-  "compilerOptions": { "rootDir": "src", "outDir": "dist", "sourceMap": true }
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "sourceMap": true
+  }
 }


### PR DESCRIPTION
## Purpose

Avoid red lines in code editors when importing Sass files.

## Approach

Include `modules.d.ts` in `src/tsconfig.json`

## Testing

Code editor should show red line on any `.scss` import in `src` before, but not after.

## Risks

None.
