### PR TITLE
fix(react): popover position

### DIFF
--- a/packages/react/src/components/popover/popover-with-portal.tsx
+++ b/packages/react/src/components/popover/popover-with-portal.tsx
@@ -20,13 +20,14 @@ export function PopoverWithPortal({
     Pick<PopoverProps, 'align' | 'position' | 'target'>
   >) {
   const domBody = useRef(document.body);
-  const [anchor, setAnchor] = useState(at(target));
+  const [, _reRender] = useState({});
+  const reRender = () => _reRender({});
 
   useOnClickOutside(onClose, [target, popover]);
 
-  useResizeObserver(() => setAnchor(at(target)), [domBody]);
+  useResizeObserver(reRender, [domBody]);
 
-  useIntersectionObserver(() => setAnchor(at(target)), [target]);
+  useIntersectionObserver(reRender, [target]);
 
   const overlay = allowOverlay && screen.width < breakpoint('small');
   useNoScroll(overlay);
@@ -35,7 +36,7 @@ export function PopoverWithPortal({
     <Portal>
       <div
         className={classy(c('popover-anchor'), m({ overlay }))}
-        style={anchor}
+        style={at(target)}
       >
         <PopoverBase {...props} ref={popover} />
       </div>


### PR DESCRIPTION
## Purpose

Make sure Popover/Tooltip/Select position is never wrong, even after layout shift or window scroll.

## Approach

When Portal'ed, always calculate position on every render.

## Testing

https://user-images.githubusercontent.com/18623773/146452684-22472fcf-fa5e-4e42-99f3-c9fa2da9513e.mov

## Risks

None, we were already executing the function anyway, now it just applies to state.
