### PR TITLE
docs: fix prepareForInline, only parse CSS stories

### DIFF
--- a/.storybook/custom/prepareForInline.tsx
+++ b/.storybook/custom/prepareForInline.tsx
@@ -1,8 +1,17 @@
+import { StoryContext } from '@storybook/react';
 import React, { ReactElement, ReactNode } from 'react';
 
 // NOTE: always execute storyFn so that source code snippets are generated
-export const prepareForInline = (storyFn: () => JSX.Element) =>
-  parse(storyFn());
+export const prepareForInline = (
+  storyFn: () => JSX.Element,
+  ctx: StoryContext
+) => {
+  const story = storyFn();
+
+  if (ctx.id.startsWith('css-')) return parse(story);
+
+  return story;
+};
 
 /**
  * Deeply parses a React structure for strings and parses those as HTML


### PR DESCRIPTION
## Purpose

Fix `prepareForInline` so that it only parses CSS.
Some React stories would break if we transformed all strings to TextNodes, like Select's.

## Approach

Only parse if story id begins with `css-`

## Testing

Select stories was broken before, couldn't select an option.
Now they're fixed.

## Risks

None.
