### PR TITLE
docs: replace "Storybook" in title with "Castor"

### DIFF
--- a/.storybook/manager.ts
+++ b/.storybook/manager.ts
@@ -9,6 +9,12 @@ export const mode = process.env.STORYBOOK_MODE; // defined on CI script
 if (env === 'production' && mode === 'production')
   window.STORYBOOK_GA_ID = process.env.STORYBOOK_GA_ID;
 
+// everytime Storybook changes the document title, replace it with "Castor"
+new MutationObserver(() => {
+  if (document.title.endsWith('Storybook'))
+    document.title = document.title.slice(0, -9) + 'Castor';
+}).observe(document.querySelector('title'), { childList: true });
+
 declare global {
   interface Window {
     STORYBOOK_GA_ID: string;


### PR DESCRIPTION
## Purpose

Have "Castor" in the browser title as a "suffix" rather than the default "Storybook"

## Approach

MutationObserver on `<title>` element

## Testing

Every story should have "Castor" as the browser title suffix

## Risks

None
