### PR TITLE
fix: button hover on iOS

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -37,9 +37,13 @@
       background-color: helpers.color('background-action');
       color: helpers.color('content-on-action');
 
-      &:hover {
-        background-color: helpers.color('background-action-hover');
+      /* stylelint-disable max-nesting-depth */
+      @media (hover: hover) {
+        &:hover {
+          background-color: helpers.color('background-action-hover');
+        }
       }
+      /* stylelint-enable max-nesting-depth */
 
       &:active {
         background-color: helpers.color('background-action-active');
@@ -49,19 +53,27 @@
     &.-action--secondary {
       border-color: helpers.color('border-action');
 
-      &:hover,
-      &:active {
-        border-color: helpers.color('border-action-hover');
+      /* stylelint-disable max-nesting-depth */
+      @media (hover: hover) {
+        &:hover,
+        &:active {
+          border-color: helpers.color('border-action-hover');
+        }
       }
+      /* stylelint-enable max-nesting-depth */
     }
 
     &.-action--secondary,
     &.-action--tertiary {
       color: helpers.color('content-action');
 
-      &:hover {
-        background-color: helpers.color('background-action-subtle-hover');
+      /* stylelint-disable max-nesting-depth */
+      @media (hover: hover) {
+        &:hover {
+          background-color: helpers.color('background-action-subtle-hover');
+        }
       }
+      /* stylelint-enable max-nesting-depth */
 
       &:active {
         background-color: helpers.color('background-action-subtle');
@@ -78,9 +90,13 @@
       background-color: helpers.color('background-negative');
       color: helpers.color('content-always-light');
 
-      &:hover {
-        background-color: helpers.color('background-negative-hover');
+      /* stylelint-disable max-nesting-depth */
+      @media (hover: hover) {
+        &:hover {
+          background-color: helpers.color('background-negative-hover');
+        }
       }
+      /* stylelint-enable max-nesting-depth */
 
       &:active {
         background-color: helpers.color('background-negative-active');
@@ -95,9 +111,13 @@
     &.-destructive--tertiary {
       color: helpers.color('content-negative');
 
-      &:hover {
-        background-color: helpers.color('background-negative-subtle-hover');
+      /* stylelint-disable max-nesting-depth */
+      @media (hover: hover) {
+        &:hover {
+          background-color: helpers.color('background-negative-subtle-hover');
+        }
       }
+      /* stylelint-enable max-nesting-depth */
 
       &:active {
         background-color: helpers.color('background-negative-subtle');


### PR DESCRIPTION
## Purpose

On iOS Safari, if you tap on an element, the hover state "sticks" and any element displayed at the same place will be in hover state.

Here's a sample to reproduce:
```
import React from "react";
import { Button } from "@onfido/castor-react";
import "@onfido/castor/dist/castor.css";
import "@onfido/castor/dist/themes/day.css";

export default function App() {
  const [page, setPage] = React.useState(1);

  const PageOne = () => <Button onClick={() => setPage(2)}>PageOne</Button>;
  const PageTwo = () => <Button onClick={() => setPage(1)}>PageTwo</Button>;

  return page === 1 ? <PageOne /> : <PageTwo />;
}

```

## Approach

Wrapping every `:hover` rule in `@media (hover: hover)` to prevent mobile device to apply the rule.

## Testing

Should pass CI since it doesn't apply to desktop browser.

## Risks

Adding the media query trigger the `max-nesting-depth`, so the rule has been disabled locally.
