### PR TITLE
docs: fix some component names

### DIFF
--- a/.storybook/custom/fixNames.ts
+++ b/.storybook/custom/fixNames.ts
@@ -1,0 +1,25 @@
+import {
+  Checkbox,
+  Fieldset,
+  Form,
+  Input,
+  Progress,
+  Radio,
+  Spinner,
+  Textarea,
+} from '@onfido/castor-react';
+import { FC } from 'react';
+
+// It is unclear why some of these fail to have their name inferred correctly
+// by Storybook tools, but for every instance where it does we can simply
+// hard-code them here.
+// Only applies to Storybook, not to the output library.
+
+(Checkbox as FC).displayName = 'Checkbox';
+(Fieldset as FC).displayName = 'Fieldset';
+(Form as FC).displayName = 'Form';
+(Input as FC).displayName = 'Input';
+(Progress as FC).displayName = 'Progress';
+(Radio as FC).displayName = 'Radio';
+(Spinner as FC).displayName = 'Spinner';
+(Textarea as FC).displayName = 'Textarea';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,7 @@ import {
   themes,
   transformSource,
 } from './custom';
+import './custom/fixNames';
 import './preview.scss';
 
 export const parameters: Parameters = {


### PR DESCRIPTION
## Purpose

Some component names are not being correctly inferred by Storybook tools.
It is unclear why, as it was working in previous versions.

## Approach

Hard-code problematic components' names in Storybook only.
Ideally we can simply remove this after tools work once again.

## Testing

Check code snippet for all components (e.g. Spinner, Radio, Checkbox) before and after change

## Risks

Temporary code tends to live longer than intended
