### PR TITLE
feat: allow external icon usage

### DIFF
--- a/packages/core/src/components/select/select.stories.ts
+++ b/packages/core/src/components/select/select.stories.ts
@@ -1,4 +1,3 @@
-import { classy, m } from '@onfido/castor';
 import { html, htmlMatrix, Meta, omit, Story } from '../../../../../docs';
 import { FieldLabel } from '../field-label/field-label.story';
 import { Field } from '../field/field.story';
@@ -14,7 +13,7 @@ export default {
   component: Select,
   render: Select,
   argTypes: {
-    ...omit('class', 'id', 'required', 'value'),
+    ...omit('class', 'empty', 'id', 'required', 'value'),
     children: {
       description: [
         'List of options using `<option>`.',
@@ -84,7 +83,7 @@ export const WithEmptyModifier: Story<SelectProps> = {
         value: '',
       }),
     ],
-    class: classy(m('empty')),
+    empty: true,
   },
 };
 

--- a/packages/core/src/components/select/select.story.tsx
+++ b/packages/core/src/components/select/select.story.tsx
@@ -5,27 +5,33 @@ import { Icon } from '../icon/icon.story';
 export interface SelectProps extends BaseProps {
   children?: string | string[] | null;
   class?: string;
+  empty?: boolean;
   id?: string;
   required?: boolean;
   value?: string;
 }
 
 /**
- * `.ods-select` uses an `.ods-icon` that requires SVG sprite to be included in
- * your app.
+ * This example uses an icon that requires Castor's SVG sprite to be included in
+ * your app:
  *
  * https://github.com/onfido/castor-icons
+ *
+ * You may also use any other SVG, but using Castor iconography is recommended.
+ *
+ * Regardless, make sure your icon has the `ods-icon` class.
  */
 export const Select = ({
   id,
   borderless,
+  empty,
   invalid,
   children,
   class: className,
   ...props
 }: SelectProps) =>
   html('div', {
-    class: classy(c('select'), m({ borderless })),
+    class: classy(c('select'), m({ borderless, empty })),
     children: [
       html('select', {
         ...props,

--- a/packages/react/src/components/search/search.stories.tsx
+++ b/packages/react/src/components/search/search.stories.tsx
@@ -1,4 +1,6 @@
+import { IconSearch } from '@onfido/castor-icons';
 import { Search, SearchProps } from '@onfido/castor-react';
+import React from 'react';
 import { Meta, reactMatrix, Story } from '../../../../../docs';
 
 const disabled = [true, false] as const;
@@ -22,5 +24,21 @@ export default {
 } as Meta<SearchProps>;
 
 export const Playground: Story<SearchProps> = {};
+
+export const InlineIcon: Story<SearchProps> = {
+  render: (props) => <Search {...props} icon={<IconSearch />} />,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+import { IconSearch } from '@onfido/castor-icons';
+
+<Search icon={<IconSearch />} placeholder="Placeholder" />
+`,
+      },
+    },
+  },
+};
+IconSearch.displayName = 'IconSearch';
 
 export const Disabled = reactMatrix(Search, { disabled });

--- a/packages/react/src/components/search/search.tsx
+++ b/packages/react/src/components/search/search.tsx
@@ -1,24 +1,30 @@
 import { c, classy } from '@onfido/castor';
-import { Icon, Input, InputProps } from '@onfido/castor-react';
+import { Input, InputProps } from '@onfido/castor-react';
 import React from 'react';
+import { MaybeIcon } from '../../internal';
 import { withRef } from '../../utils';
 
 /**
- * `Search` uses an `Icon` that requires `Icons` (SVG sprite) to be included in
- * your app.
+ * `Search` by default uses an `Icon` that requires `Icons` (SVG sprite) to be
+ * included in your app.
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
+ *
+ * You may also provide any other SVG element via the `icon` prop, but using
+ * Castor iconography is recommended.
  */
 export const Search = withRef(function Search(
-  { className, style, ...restProps }: SearchProps,
+  { className, icon, style, ...restProps }: SearchProps,
   ref: SearchProps['ref']
 ) {
   return (
     <div className={classy(c('search'), className)} style={style}>
       <Input {...restProps} ref={ref} type="search" />
-      <Icon name="search" aria-hidden="true" />
+      <MaybeIcon icon={icon} name="search" />
     </div>
   );
 });
 
-export type SearchProps = Omit<InputProps, 'type' | 'invalid' | 'children'>;
+export type SearchProps = Omit<InputProps, 'type' | 'invalid' | 'children'> & {
+  icon?: JSX.Element;
+};

--- a/packages/react/src/components/select/select.stories.tsx
+++ b/packages/react/src/components/select/select.stories.tsx
@@ -1,3 +1,4 @@
+import { IconChevronDown } from '@onfido/castor-icons';
 import {
   Field,
   FieldLabel,
@@ -47,7 +48,7 @@ export default {
         </Option>
         <Option value={1}>Option 1</Option>
         <Option value={2}>Option 2</Option>
-        <Option value="long">Longer option that’s quite long</Option>
+        <Option value="long">Longer option that is quite long</Option>
         <Option value="enormous">
           An enormously long option that we truncate when it gets too long for a
           flexible width box
@@ -63,6 +64,24 @@ export default {
 } as Meta<SelectProps>;
 
 export const Playground: Story<SelectProps> = {};
+
+export const InlineIcon: Story<SelectProps> = {
+  render: (props) => <Select {...props} icon={<IconChevronDown />} />,
+  parameters: {
+    docs: {
+      source: {
+        code: `
+import { IconChevronDown } from '@onfido/castor-icons';
+
+<Select icon={<IconChevronDown />}>
+  {/* options */}
+</Select>
+`,
+      },
+    },
+  },
+};
+IconChevronDown.displayName = 'IconChevronDown';
 
 export const Borderless = reactMatrix(Select, { borderless });
 export const Invalid = reactMatrix(Select, { invalid });

--- a/packages/react/src/components/select/select.tsx
+++ b/packages/react/src/components/select/select.tsx
@@ -1,24 +1,30 @@
 import { c, classy, m, SelectProps as BaseProps } from '@onfido/castor';
-import { Icon } from '@onfido/castor-react';
 import React, { ForwardedRef, useEffect, useState } from 'react';
+import { MaybeIcon } from '../../internal';
 import { useForwardedRef, withRef } from '../../utils';
 import { CustomSelect, CustomSelectProps } from './custom';
 import { NativeSelect, NativeSelectProps } from './native';
 import { SelectProvider } from './useSelect';
 
-export type SelectProps =
-  | ({ native: true } & BaseProps & NativeSelectProps)
-  | ({ native?: false } & BaseProps &
-      Omit<CustomSelectProps, 'open' | 'onOpenChange'>);
+export type SelectProps = (Native | Custom) & {
+  icon?: JSX.Element;
+};
+
+type Native = { native: true } & BaseProps & NativeSelectProps;
+type Custom = { native?: false } & BaseProps &
+  Omit<CustomSelectProps, 'open' | 'onOpenChange'>;
 
 /**
- * `Select` uses an `Icon` that requires `Icons` (SVG sprite) to be included in
- * your app.
+ * `Select` by default uses an `Icon` that requires `Icons` (SVG sprite) to be
+ * included in your app.
  *
  * https://github.com/onfido/castor-icons#use-with-plain-code
+ *
+ * You may also provide any other SVG element via the `icon` prop, but using
+ * Castor iconography is recommended.
  */
 export const Select = withRef(function Select(
-  { borderless, className, native, onChange, ...restProps }: SelectProps,
+  { borderless, className, icon, native, onChange, ...restProps }: SelectProps,
   ref: ForwardedRef<HTMLSelectElement>
 ) {
   const { defaultValue, value } = restProps;
@@ -50,7 +56,7 @@ export const Select = withRef(function Select(
           }}
           onOpenChange={setOpen}
         />
-        <Icon name="chevron-down" aria-hidden="true" />
+        <MaybeIcon icon={icon} name="chevron-down" />
       </SelectProvider>
     </div>
   );

--- a/packages/react/src/internal/index.ts
+++ b/packages/react/src/internal/index.ts
@@ -1,1 +1,2 @@
 export * from './indicator-container/indicator-container';
+export * from './maybe-icon/maybe-icon';

--- a/packages/react/src/internal/maybe-icon/maybe-icon.tsx
+++ b/packages/react/src/internal/maybe-icon/maybe-icon.tsx
@@ -1,0 +1,16 @@
+import { c, classy } from '@onfido/castor';
+import { IconName } from '@onfido/castor-icons';
+import { Icon } from '@onfido/castor-react';
+import React from 'react';
+
+interface Props {
+  icon?: JSX.Element;
+  name: IconName;
+}
+
+export const MaybeIcon = ({ icon, name }: Props) =>
+  icon ? (
+    <div className={classy(c('icon'))}>{icon}</div>
+  ) : (
+    <Icon name={name} aria-hidden="true" />
+  );


### PR DESCRIPTION
## Purpose

Some apps have a strict size restriction and can't simply include all `<Icons />` provided as an SVG sheet.
That means using `Select` and `Search` can have serious size implications.

Currently, their only option is to construct their own SVG sheet, presumably by taking the one provided by `@onfido/castor-icons` and removing unused icons.

This PR aims to offer an alternative in a per-component API to replace default icons.

## Approach

Offer an `icon` prop that allows overriding default icon.

```tsx
import { IconSearch } from '@onfido/castor-icons';

<Search icon={<IconSearch />} />
```

Because the prop accepts a `JSX.Element`, it is not limited to `@onfido/castor-icons`, any React component's output will work.

## Testing

Modified Select and Search stories, including a new story to demonstrate how to use the new API.

## Risks

Elements in component props is not an ergonomic API in my opinion, we should still prefer `children` and composition.
However this is an exception with limited applications and it prevents weird APIs like wrapping special children in React context.

**We could also simply use inline icons in those components and accept the trade-off of more runtime DOM elements but reduced bundle size.**
A valid alternative in case we don't want to extend components with the proposed API.