### PR TITLE
fix(core): automatically include required component styles for combobox

### DIFF
--- a/packages/core/src/components/combobox/combobox.scss
+++ b/packages/core/src/components/combobox/combobox.scss
@@ -1,7 +1,14 @@
 @use '../../helpers';
 @use '../../mixins';
+@use '../icon/icon';
+@use '../option-list/option-list';
+@use '../popover/popover';
 
 @mixin Combobox() {
+  @include icon.Icon();
+  @include option-list.OptionList();
+  @include popover.Popover();
+
   @if not mixins.includes('Combobox') {
     @include _Combobox();
   }


### PR DESCRIPTION
## Purpose

Combobox requires some other component styling in order to work properly.

If each component styling is included in the app individually (with Sass), some not included automatically.

## Approach

Include required styles by default.

## Testing

On app that requires individual component styling inclusion (e.g. SDK).

## Risks

N/A
