### PR TITLE
fix(core): adjust combobox styling when used alongside field label

### DIFF
--- a/packages/core/src/components/field-label/field-label.scss
+++ b/packages/core/src/components/field-label/field-label.scss
@@ -17,6 +17,7 @@
     padding: helpers.space(0.5) 0;
     width: 100%;
 
+    > .ods-combobox,
     > .ods-input,
     > .ods-select,
     > .ods-textarea {


### PR DESCRIPTION
## Purpose

When a form component is used alongside field label, it requires some style adjustment.

## Approach

Same as other components, include Combobox into adjustment selection.

## Testing

N/A

## Risks

N/A
