### PR TITLE
fix(react): correctly validate selected option on select/combobox

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -42,10 +42,9 @@ export const CustomSelect = withRef(function CustomSelect(
   ref: ForwardedRef<HTMLSelectElement>
 ) {
   const selectRef = useForwardedRef(ref);
-  const [selected, _setSelected] = useState<OptionListEvent>({});
+  const [selected, setSelected] = useState<OptionListEvent>({});
 
-  const setSelected = useCallback((selected) => {
-    _setSelected(selected);
+  const propagateOnChange = useCallback(() => {
     // propagate `onChange` manually because <select> won't naturally when its
     // value is changed programatically by React, and on next tick, because
     // React needs to update its value first
@@ -132,6 +131,7 @@ export const CustomSelect = withRef(function CustomSelect(
             value={selected.value ?? value ?? defaultValue}
             onChange={(selected) => {
               setSelected(selected);
+              propagateOnChange();
               close();
             }}
           >
@@ -144,7 +144,12 @@ export const CustomSelect = withRef(function CustomSelect(
         <OptionListInit
           defaultValue={defaultValue}
           value={value}
-          onInit={setSelected}
+          onInit={(selected) => {
+            setSelected(selected);
+            if (selected.value) {
+              propagateOnChange();
+            }
+          }}
         >
           {children}
         </OptionListInit>


### PR DESCRIPTION
## Purpose

Correctly validate selected option on select/combobox.

## Approach

When initiating - set value based on `value` on `defaultValue`, propagate `onChange` in case option value is set so that field could be properly validated, otherwise only adjust the placeholder.

This also required hidden Combobox component (that controls the form value) to be changed from `<input>` to `<select>`.

## Testing

Tested via a form, locally.

## Risks

N/A
