### PR TITLE
fix(react): don't focus on 1st option when clicking on combobox

### DIFF
--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -131,9 +131,6 @@ export const Combobox = withRef(function Combobox(
           if (!open) {
             setOpen(true);
             preventBlur.current = true;
-            setTimeout(() =>
-              focus(optionsRef.current?.querySelector('input:enabled'))
-            );
           }
 
           onClick?.(event);


### PR DESCRIPTION
## Purpose

When clicking on Combobox, dropdown should open but input should not lose focus.

## Approach

Don't focus on 1st option when clicking on component which opens a dropdown.

## Testing

On Storybook.

## Risks

N/A
