### PR TITLE
fix(react): make sure custom-select reacts to value change

### DIFF
--- a/packages/react/src/components/select/custom/custom-select.tsx
+++ b/packages/react/src/components/select/custom/custom-select.tsx
@@ -3,6 +3,7 @@ import React, {
   ForwardedRef,
   SyntheticEvent,
   useCallback,
+  useEffect,
   useState,
 } from 'react';
 import { useForwardedRef, withRef } from '../../../utils';
@@ -43,6 +44,10 @@ export const CustomSelect = withRef(function CustomSelect(
 ) {
   const selectRef = useForwardedRef(ref);
   const [selected, setSelected] = useState<OptionListEvent>({});
+
+  useEffect(() => {
+    if (selected.option) setSelected({ value });
+  }, [value]);
 
   const propagateOnChange = useCallback(() => {
     // propagate `onChange` manually because <select> won't naturally when its


### PR DESCRIPTION
## Purpose

Fixing bug where `CustomSelect` does not react when `value` is being changed for a component via the prop.

## Approach

Listen for `value` change, set selection to that value.

## Testing

Tested locally in a hacky way.

## Risks

N/A
