### PR TITLE
fix: update IndicatorContainer children type

### DIFF
--- a/packages/react/src/internal/indicator-container/indicator-container.tsx
+++ b/packages/react/src/internal/indicator-container/indicator-container.tsx
@@ -1,6 +1,6 @@
 import { c, classy, m } from '@onfido/castor';
 import { IndicatorContainerProps as BaseProps } from '@onfido/castor/src/internal';
-import React from 'react';
+import React, { ReactElement } from 'react';
 
 export * from './splitContainerProps';
 
@@ -28,7 +28,7 @@ export type IndicatorContainerProps = BaseProps &
   Omit<LabelElementProps, 'children'> & {
     children: {
       children: LabelElementProps['children'];
-      input: JSX.IntrinsicElements['input'];
+      input: ReactElement & JSX.IntrinsicElements['input'];
     };
   };
 


### PR DESCRIPTION
## Purpose

Castor React typing is not compatible with React 18 projects.

## Approach

They removed `{}` from `ReactFragment` type in React 18 (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56026):

So now, anything that does not match a `ReactNode` will fail type checking. And `JSX.IntrinsicElements['input']` type has no overlap with `ReactNode` type: it misses the `props` property.

The solution would be to do a union of `JSX.IntrinsicElements['input']` with `ReactElement`, to get the missing `props` property.

## Testing

Tested with a React 18 project.

## Risks

N/A