### PR TITLE
chore: enforce NodeJS <18

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">= 16.14"
+    "node": ">= 16.14 < 18.0.0"
   },
   "scripts": {
     "start": "start-storybook -p 6006",


### PR DESCRIPTION
## Purpose

Vercel upgrade NodeJS to version 18 causing issue with the build.

```Error: error:0308010C:digital envelope routines::unsupported```

## Approach

Enforce NodeJS <18

## Testing

N/A

## Risks

N/A