### PR TITLE
Fix couple typescript issues

### DIFF
--- a/packages/react/src/components/combobox/combobox.tsx
+++ b/packages/react/src/components/combobox/combobox.tsx
@@ -122,6 +122,7 @@ export const Combobox = withRef(function Combobox(
           setSearch(undefined);
           close();
           onBlur?.(event);
+          return preventBlur.current;
         }}
         onChange={(event) => {
           setInput(event.target.value);


### PR DESCRIPTION
## Purpose

Castor typescript was broken

```
node_modules/@onfido/castor-react/src/components/combobox/combobox.tsx:118:17 - error TS7030: Not all code paths return a value.

118         onBlur={(event) => {
                    ~~~~~~~~~~~~

node_modules/@onfido/castor-react/src/internal/indicator-container/indicator-container.tsx:17:4 - error TS2746: This JSX tag's 'children' prop expects a single child of type 'ReactNode', but multiple children were provided.

17   <label
      ~~~~~


Found 2 errors in 2 files.
```
