### PR TITLE
fix(a11y): set  to hidden input

### DIFF
--- a/packages/react/src/components/option-list/option.tsx
+++ b/packages/react/src/components/option-list/option.tsx
@@ -53,6 +53,7 @@ export function Option({
       }}
     >
       <input
+        aria-hidden={true}
         className={classy(c('option-input'))}
         checked={selected}
         disabled={disabled}


### PR DESCRIPTION
## Purpose

OptionList component does not pass a11y checks. The Option component is missing a role:

```html
<label data-qa="bank_building_society_statement" class="ods-option">
 <input readonly="" type="radio" aria-hidden="true">
 <span role="option" class="ods-option-content"></span>
</label>
```

`input` is a children of a `role="list"` so it needs to have a role or to be marked as aria-hidden.

## Approach

Because `input` is visually hidden it should be aria-hidden.